### PR TITLE
fix docker push image name to output-producer.

### DIFF
--- a/docker-compose.deploy.images.yml
+++ b/docker-compose.deploy.images.yml
@@ -1,6 +1,6 @@
 version: '3.7'
 services:
   backend:
-    image: 'openstax/pdf-spike-${DOCKER_IMAGE_BACKEND}:${TAG-latest}'
+    image: 'openstax/output-producer-${DOCKER_IMAGE_BACKEND}:${TAG-latest}'
   frontend:
-    image: 'openstax/pdf-spike-${DOCKER_IMAGE_FRONTEND}:${TAG-latest}'
+    image: 'openstax/output-producer-${DOCKER_IMAGE_FRONTEND}:${TAG-latest}'

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,4 +10,4 @@ docker-compose \
 -f docker-compose.deploy.images.yml \
 config > docker-stack.yml
 
-docker-compose -f docker-stack.yml build
+docker-compose -f docker-stack.yml build --no-cache


### PR DESCRIPTION
* build-push script was naming the images with pdf-spike-\*. This is now
changed to output-producer-*.
* added `--no-cache` to the `build.sh` script. Ensure images are pushed
up fresh each time.