### PR TITLE
remove async from path definition functions for the jobs endpoint and add timeout to gunicorn config

### DIFF
--- a/backend/app/app/api/endpoints/jobs.py
+++ b/backend/app/app/api/endpoints/jobs.py
@@ -11,7 +11,7 @@ router = APIRouter()
 
 
 @router.get("/", response_model=List[Job])
-async def list_jobs(
+def list_jobs(
         db: Session = Depends(get_db),
         skip: int = 0,
         limit: int = 100,
@@ -22,7 +22,7 @@ async def list_jobs(
 
 
 @router.get("/{id}", response_model=Job)
-async def get_job(
+def get_job(
         *,
         db: Session = Depends(get_db),
         id: int
@@ -35,7 +35,7 @@ async def get_job(
 
 
 @router.post("/", response_model=Job)
-async def create_job(
+def create_job(
         *,
         db: Session = Depends(get_db),
         job_in: JobCreate
@@ -46,7 +46,7 @@ async def create_job(
 
 
 @router.put("/{id}", response_model=Job)
-async def update_job(
+def update_job(
         *,
         db: Session = Depends(get_db),
         id: int,

--- a/backend/app/bin/db_wait.py
+++ b/backend/app/bin/db_wait.py
@@ -25,6 +25,8 @@ def init():
     except Exception as e:
         logger.error(e)
         raise e
+    finally:
+        db_session.close()
 
 
 def main():

--- a/backend/docker/gunicorn.conf
+++ b/backend/docker/gunicorn.conf
@@ -28,6 +28,7 @@ workers = web_concurrency
 bind = use_bind
 keepalive = 120
 errorlog = "-"
+timeout = 120
 
 # For debugging and testing
 log_data = {


### PR DESCRIPTION
* added config to gunicorn to timeout after 120 seconds. ref: https://docs.gunicorn.org/en/stable/settings.html#timeout
* added a finally block to try/except in the db_wait.py script that checks to see if the db is up before starting. The finally block closes the database session.
* Removed async from path operations where there is blocking db queries.