### PR TITLE
Update files to be able to deploy COPS using docker stack

### DIFF
--- a/docker-compose.deploy.labels.yml
+++ b/docker-compose.deploy.labels.yml
@@ -26,7 +26,7 @@ services:
         - traefik.port=80
         - traefik.tags=${TRAEFIK_PUBLIC_TAG}
         - traefik.docker.network=${TRAEFIK_PUBLIC_NETWORK}
-#        # Traefik service that listens to HTTP
+        # Traefik service that listens to HTTP
         - traefik.servicehttp.frontend.entryPoints=http
         - traefik.servicehttp.frontend.redirect.entryPoint=https
         # Traefik service that listens to HTTPS
@@ -45,6 +45,7 @@ services:
         - traefik.enable=true
         - traefik.port=80
         - traefik.tags=${TRAEFIK_TAG}
+        - traefik.docker.network=traefik-public
   frontend:
     deploy:
       labels:
@@ -52,3 +53,4 @@ services:
         - traefik.enable=true
         - traefik.port=80
         - traefik.tags=${TRAEFIK_TAG}
+        - traefik.docker.network=traefik-public

--- a/docker-compose.deploy.labels.yml
+++ b/docker-compose.deploy.labels.yml
@@ -14,34 +14,34 @@ services:
         # Traefik service that listens to HTTPS
         - traefik.webservice.frontend.entryPoints=https
 # Traefik is already deployed as an external service
-#  proxy:
-#    deploy:
-#      labels:
-#        # For the configured domain
-#        - traefik.frontend.rule=Host:${DOMAIN}
-#        # For a domain with and without 'www'
-#        # Comment the previous line above and un-comment the line below
-#        # - "traefik.frontend.rule=Host:www.${DOMAIN},${DOMAIN}"
-#        - traefik.enable=true
-#        - traefik.port=80
-#        - traefik.tags=${TRAEFIK_PUBLIC_TAG}
-#        - traefik.docker.network=${TRAEFIK_PUBLIC_NETWORK}
+  proxy:
+    deploy:
+      labels:
+        # For the configured domain
+        - traefik.frontend.rule=Host:${DOMAIN}
+        # For a domain with and without 'www'
+        # Comment the previous line above and un-comment the line below
+        # - "traefik.frontend.rule=Host:www.${DOMAIN},${DOMAIN}"
+        - traefik.enable=true
+        - traefik.port=80
+        - traefik.tags=${TRAEFIK_PUBLIC_TAG}
+        - traefik.docker.network=${TRAEFIK_PUBLIC_NETWORK}
 #        # Traefik service that listens to HTTP
-#        - traefik.servicehttp.frontend.entryPoints=http
-#        - traefik.servicehttp.frontend.redirect.entryPoint=https
-#        # Traefik service that listens to HTTPS
-#        - traefik.servicehttps.frontend.entryPoints=https
-#        # Uncomment the config line below to detect and redirect www to non-www (or the contrary)
-#        # The lines above for traefik.frontend.rule are needed too
-#        # - "traefik.servicehttps.frontend.redirect.regex=^https?://(www.)?(${DOMAIN})/(.*)"
-#        # To redirect from non-www to www un-comment the line below
-#        # - "traefik.servicehttps.frontend.redirect.replacement=https://www.${DOMAIN}/$$3"
-#        # To redirect from www to non-www un-comment the line below
-#        # - "traefik.servicehttps.frontend.redirect.replacement=https://${DOMAIN}/$$3"
+        - traefik.servicehttp.frontend.entryPoints=http
+        - traefik.servicehttp.frontend.redirect.entryPoint=https
+        # Traefik service that listens to HTTPS
+        - traefik.servicehttps.frontend.entryPoints=https
+        # Uncomment the config line below to detect and redirect www to non-www (or the contrary)
+        # The lines above for traefik.frontend.rule are needed too
+        # - "traefik.servicehttps.frontend.redirect.regex=^https?://(www.)?(${DOMAIN})/(.*)"
+        # To redirect from non-www to www un-comment the line below
+        # - "traefik.servicehttps.frontend.redirect.replacement=https://www.${DOMAIN}/$$3"
+        # To redirect from www to non-www un-comment the line below
+        # - "traefik.servicehttps.frontend.redirect.replacement=https://${DOMAIN}/$$3"
   backend:
     deploy:
       labels:
-        - traefik.frontend.rule=PathPrefix:/api,/docs,/redoc
+        - traefik.frontend.rule=PathPrefix:/api,/docs,/redoc,/openapi.json
         - traefik.enable=true
         - traefik.port=80
         - traefik.tags=${TRAEFIK_TAG}

--- a/docker-compose.deploy.volumes-placement.yml
+++ b/docker-compose.deploy.volumes-placement.yml
@@ -12,6 +12,7 @@ services:
       placement:
         constraints:
           - node.role == manager
+          - node.labels.${STACK_NAME}.proxy == true
 
 volumes:
   app-db-data:

--- a/docker-compose.shared.env.yml
+++ b/docker-compose.shared.env.yml
@@ -6,6 +6,7 @@ services:
       - env-postgres.env
     environment:
       - SERVER_NAME=${DOMAIN}
+      - SERVER_HOST=https://${DOMAIN}
   db:
     env_file:
       - env-postgres.env


### PR DESCRIPTION
* Added a docker-compose.deploy.ports.yml to map the appropriate ports and services.
* Update docker-compose.deploy.lables.yml to have the openapi.json route for the backend
* Added ${STACK_NAME} variable to be able to define various environments ie. staging, prod, etc
* Added the docker-compse.deploy.ports.yml file to `/scripts/deploy.sh`
* Added `SERVER_HOST` env var to docker-compose.shared.env.yml file 