### PR TITLE
Fix mobile production rendering

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -13,5 +13,6 @@ module.exports = {
   ],
   // add your custom rules here
   rules: {
+    'no-console': 'off'
   }
 }

--- a/frontend/assets/main.scss
+++ b/frontend/assets/main.scss
@@ -1,5 +1,5 @@
 .mainscreen {
-  margin-top: 5vh;
+  margin-top: 2vh;
 }
 
 @media (min-width: 768px) and (min-height: 638px) {

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -7,7 +7,7 @@ export default {
   ** Headers of the page
   */
   head: {
-    titleTemplate: '%s - ' + process.env.npm_package_name,
+    titleTemplate: 'COPS - Content Output Producers',
     title: process.env.npm_package_name || '',
     meta: [
       { charset: 'utf-8' },

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -21,12 +21,18 @@
               large
               tile
             >
-              <span>Create a new PDF job</span><v-icon class="ml-2">mdi-file-document-box-plus-outline</v-icon>
+              <span>Create a new PDF job</span>
+              <v-icon class="ml-2">
+                mdi-file-document-box-plus-outline
+              </v-icon>
             </v-btn>
           </template>
           <v-card>
             <v-card-title class="headline grey lighten-2" primary-title>
-              <v-icon class="mr-1" large>mdi-file-document-box-plus-outline</v-icon><span>Create a new PDF</span>
+              <v-icon class="mr-1" large>
+                mdi-file-document-box-plus-outline
+              </v-icon>
+              <span>Create a new PDF</span>
             </v-card-title>
             <v-card-text>
               <v-container>
@@ -67,7 +73,7 @@
               </v-container>
               <small>*indicates required field</small>
             </v-card-text>
-            <v-divider/>
+            <v-divider />
             <v-card-actions>
               <v-spacer />
               <v-btn @click="dialog = false" color="blue darken-1" text>
@@ -81,6 +87,7 @@
         </v-dialog>
       </div>
       <v-data-table
+        v-if="browserReady"
         :headers="headers"
         :items="jobs"
         :disable-pagination="true"
@@ -153,7 +160,8 @@ export default {
       version: '',
       style: '',
       polling: null,
-      contentServerId: null
+      contentServerId: null,
+      browserReady: false
     }
   },
   computed: {
@@ -166,6 +174,9 @@ export default {
   },
   created () {
     this.pollData()
+  },
+  mounted () {
+    this.browserReady = true
   },
   beforeDestroy () {
     clearInterval(this.polling)


### PR DESCRIPTION
* remove console warnings on build
* fix CSS on mobile
* fix title

SSR does too much on the dynamic data-table and will break nuxt SSR (I think it's a deep internal bug with Nuxt, mobile breakpoints and Vuetify). To resolve that the data-table is loaded once the browser window is ready to paint, that means `mounted`. This way the dynamic data-table rendering is not confused on mobile first load. Another benefit is also that it feels faster because CSS and HTML data is now loaded in right order (there is a treeshaking bug in Vuetify in combination with Nuxt SSR).