### PR TITLE
Added add-content-server management command to manage.py

### DIFF
--- a/backend/app/app/db/schema.py
+++ b/backend/app/app/db/schema.py
@@ -8,9 +8,9 @@ from app.db.base_class import Base
 
 class ContentServers(Base):
     id = sa.Column(sa.Integer, primary_key=True, index=True)
-    hostname = sa.Column(sa.String)
-    host_url = sa.Column(sa.String)
-    name = sa.Column(sa.String)
+    hostname = sa.Column(sa.String, nullable=False)
+    host_url = sa.Column(sa.String, nullable=False)
+    name = sa.Column(sa.String, nullable=False)
     created_at = sa.Column(sa.DateTime, nullable=False, default=datetime.utcnow, index=True)
     updated_at = sa.Column(sa.DateTime, nullable=False, default=datetime.utcnow,
                            onupdate=datetime.utcnow)

--- a/backend/app/manage.py
+++ b/backend/app/manage.py
@@ -1,5 +1,9 @@
 import click
 
+from app.db.schema import ContentServers
+from app.db.session import db_session
+
+
 @click.group()
 def cli():
     pass
@@ -18,7 +22,25 @@ def reset_db():
     click.echo('Database has been reset')
 
 
+@click.command()
+@click.option('-h', '--hostname', required=True, type=str)
+@click.option('-n', '--name', required=True, type=str)
+@click.option('-u', '--host_url', required=True, type=str)
+def add_content_server(hostname, name, host_url):
+    """Add a new content server to the database"""
+
+    content_server = ContentServers(hostname=hostname,
+                                    name=name,
+                                    host_url=host_url)
+    db_session.add(content_server)
+    db_session.commit()
+
+    click.echo(f'Content server added\n'
+               f'hostname: {hostname}\nname:{name}\nurl:{host_url}')
+
+
 cli.add_command(reset_db)
+cli.add_command(add_content_server)
 
 if __name__ == '__main__':
     cli()

--- a/backend/app/migrations/versions/59dbc5b20d2e_make_content_server_fields_not_nullable.py
+++ b/backend/app/migrations/versions/59dbc5b20d2e_make_content_server_fields_not_nullable.py
@@ -1,0 +1,40 @@
+"""make content_server fields not nullable
+
+Revision ID: 59dbc5b20d2e
+Revises: 6b83ef5cce00
+Create Date: 2020-01-17 23:00:54.736531
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '59dbc5b20d2e'
+down_revision = '6b83ef5cce00'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('content_servers', 'host_url',
+               existing_type=sa.VARCHAR(),
+               nullable=False)
+    op.alter_column('content_servers', 'hostname',
+               existing_type=sa.VARCHAR(),
+               nullable=False)
+    op.alter_column('content_servers', 'name',
+               existing_type=sa.VARCHAR(),
+               nullable=False)
+
+
+def downgrade():
+    op.alter_column('content_servers', 'name',
+               existing_type=sa.VARCHAR(),
+               nullable=True)
+    op.alter_column('content_servers', 'hostname',
+               existing_type=sa.VARCHAR(),
+               nullable=True)
+    op.alter_column('content_servers', 'host_url',
+               existing_type=sa.VARCHAR(),
+               nullable=True)


### PR DESCRIPTION
* added add-content-server management command to manage.py
* made server attribute fields on the content_servers table not nullable.
* added database migration to reflect not nullable fields in the database.

To add a content server you can now do:

`python manage.py add-content-server -h cnx.org -u https://cnx.org -n production`