### PR TITLE
added docker-compose.deploy file for rolling updates and updated deploy script

### DIFF
--- a/docker-compose.deploy.settings.yml
+++ b/docker-compose.deploy.settings.yml
@@ -1,0 +1,18 @@
+version: "3.7"
+services:
+  backend:
+    deploy:
+      replicas: 2
+      update_config:
+        parallelism: 1
+        delay: 10s
+      restart_policy:
+        condition: on-failure
+  frontend:
+    deploy:
+      replicas: 2
+      update_config:
+        parallelism: 1
+        delay: 10s
+      restart_policy:
+        condition: on-failure

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -17,6 +17,7 @@ docker-compose \
 -f docker-compose.deploy.labels.yml \
 -f docker-compose.deploy.networks.yml \
 -f docker-compose.deploy.volumes-placement.yml \
+-f docker-compose.deploy.settings.yml \
 config > docker-stack.yml
 
 docker-auto-labels docker-stack.yml


### PR DESCRIPTION
* added docker-compose.deploy.settings.yml file for rolling updates. Backend and frontend now have 2 containers each. A 10 sec delay has been added before they are switched over. One container will be brought down and replaced with the updated container. 10 sec later the traffic will be routed to the new container.
* deploy script updated to use new compose file