### PR TITLE
Updates needed to accomodate the move to AWS

### DIFF
--- a/docker-compose.deploy.build.yml
+++ b/docker-compose.deploy.build.yml
@@ -7,3 +7,6 @@ services:
   frontend:
     build:
       context: ./frontend
+      args:
+        API_URL: https://${DOMAIN}
+        API_URL_BROWSER: https://${DOMAIN}

--- a/docker-compose.deploy.settings.yml
+++ b/docker-compose.deploy.settings.yml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
   backend:
     deploy:
-      replicas: 2
+      replicas: 1
       update_config:
         parallelism: 1
         delay: 10s
@@ -10,7 +10,7 @@ services:
         condition: on-failure
   frontend:
     deploy:
-      replicas: 2
+      replicas: 1
       update_config:
         parallelism: 1
         delay: 10s

--- a/docker-compose.deploy.volumes-placement.yml
+++ b/docker-compose.deploy.volumes-placement.yml
@@ -2,21 +2,18 @@ version: '3.7'
 services:
   db:
     volumes:
-      - app-db-data:/var/lib/postgresql/data/pgdata
+      - ${STACK_NAME}-db-data:/var/lib/postgresql/data/pgdata
     deploy:
       placement:
         constraints:
-          - node.labels.${STACK_NAME}.app-db-data == true
+          - node.role == manager
+          - node.labels.db-data == true
   proxy:
     deploy:
       placement:
         constraints:
           - node.role == manager
-          - node.labels.${STACK_NAME}.proxy == true
-    volumes:
-      - type: volume
-        source: traefik-public-certificates
-        target: /certificates
+          - node.labels.proxy == true
 
 volumes:
   app-db-data:

--- a/docker-compose.deploy.volumes-placement.yml
+++ b/docker-compose.deploy.volumes-placement.yml
@@ -2,12 +2,12 @@ version: '3.7'
 services:
   db:
     volumes:
-      - ${STACK_NAME}-db-data:/var/lib/postgresql/data/pgdata
+      - app-db-data:/var/lib/postgresql/data/pgdata
     deploy:
       placement:
         constraints:
           - node.role == manager
-          - node.labels.db-data == true
+          - node.labels.app-db-data == true
   proxy:
     deploy:
       placement:

--- a/frontend/localConfig.js
+++ b/frontend/localConfig.js
@@ -1,5 +1,5 @@
 const config = {
-  apiBaseURL: process.env.API_URL || 'https://cops.cnx.org',
-  browserBaseURL: process.env.API_URL_BROWSER || 'https://cops.cnx.org'
+  apiBaseURL: process.env.API_URL || 'https://cops.openstax.org',
+  browserBaseURL: process.env.API_URL_BROWSER || 'https://cops.openstax.org'
 }
 module.exports = config


### PR DESCRIPTION
* Change labels used for constraints to be node specific
* Update frontend config to use cops.openstax.org by default if not provided with a build var.
* Changed replicas back down to 1 for FE and BE
