### PR TITLE
Add basic back + front end pagination support

### DIFF
--- a/backend/app/app/api/endpoints/jobs.py
+++ b/backend/app/app/api/endpoints/jobs.py
@@ -14,10 +14,25 @@ router = APIRouter()
 def list_jobs(
         db: Session = Depends(get_db),
         skip: int = 0,
-        limit: int = 100,
+        limit: int = 50,
 ):
-    """List jobs"""
-    jobs = jobs_service.get_items(db, skip=skip, limit=limit)
+    """List jobs - page 0"""
+    return list_job_page(db, 0, limit)
+
+
+@router.get("/pages/{page}", response_model=List[Job])
+def list_job_page(
+        db: Session = Depends(get_db),
+        page: int = 0,
+        limit: int = 50,
+):
+    """List jobs by page"""
+    skip = page * limit
+    order_by = jobs_service.schema_model.created_at.desc()
+    jobs = jobs_service.get_items_order_by(db,
+                                           skip=skip,
+                                           limit=limit,
+                                           order_by=[order_by])
     return jobs
 
 

--- a/backend/app/app/service/base.py
+++ b/backend/app/app/service/base.py
@@ -25,6 +25,9 @@ class ServiceBase(object):
         return db_session.query(self.schema_model).offset(skip).limit(limit).filter_by(
             **kwargs).all()
 
+    def get_items_order_by(self, db_session: BaseSession, *, skip=0, limit=100, order_by=[]):
+        return db_session.query(self.schema_model).order_by(*order_by).offset(skip).limit(limit).all()
+
     def create(self, db_session: BaseSession, obj_in: BaseModel) -> BaseSchema:
         obj_data = jsonable_encoder(obj_in)
 

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -94,14 +94,41 @@
           </v-card>
         </v-dialog>
       </div>
+      <div class="d-md-flex">
+        <v-btn
+          @click="toPage(Math.max(0, current_page - 1))"
+          class="ma-1"
+        >
+          Previous Page
+        </v-btn>
+        <v-btn
+          @click="toPage(current_page + 1)"
+          class="ma-1"
+        >
+          Next Page
+        </v-btn>
+        <v-text-field
+          class="ma-1"
+          style="max-width: 100px"
+          label="Jump To"
+          outlined
+          dense
+          hide-details
+          v-model="goto_page"
+        />
+        <v-btn
+          @click="toPage(Math.max(0, parseInt(goto_page) || 0))"
+          class="ma-1"
+        >
+          Go
+        </v-btn>
+      </div>
       <v-data-table
         v-if="browserReady"
         :headers="headers"
         :items="jobs"
         :disable-pagination="true"
         :hide-default-footer="true"
-        :sort-by="'updated_at'"
-        :sort-desc="true"
         class="elevation-1"
       >
         <template v-slot:item.created_at="{ item }">
@@ -170,6 +197,8 @@ export default {
       polling: null,
       contentServerId: null,
       browserReady: false,
+      current_page: 0,
+      goto_page: '',
       valid: false,
       collectionRules: [
         v => !!v || 'Collection ID is required',
@@ -215,6 +244,7 @@ export default {
     }
   },
   created () {
+    this.getJobsImmediate()
     this.pollData()
   },
   mounted () {
@@ -224,10 +254,13 @@ export default {
     clearInterval(this.polling)
   },
   methods: {
+    getJobsImmediate () {
+      this.$store.dispatch('getJobsForPage', { page: this.current_page })
+      console.log('get JOBS now...')
+    },
     pollData () {
       this.polling = setInterval(() => {
-        this.$store.dispatch('getJobs')
-        console.log('get JOBS now...')
+        this.getJobsImmediate()
       }, 30000)
     },
     showStatus (status) {
@@ -250,6 +283,10 @@ export default {
       this.dialog = false
       this.$refs.form.resetValidation()
       this.$refs.form.reset()
+    },
+    toPage (number) {
+      this.current_page = number
+      this.getJobsImmediate()
     },
     clickCollection (collectionId, contentServerId, version, style) {
       if (this.$refs.form.validate()) {

--- a/frontend/store/index.js
+++ b/frontend/store/index.js
@@ -35,8 +35,8 @@ export const actions = {
     await dispatch('getJobs')
     await dispatch('getContentServers')
   },
-  async getJobs ({ commit }) {
-    const response = await this.$axios.$get('/api/jobs/')
+  async getJobsForPage ({ commit }, { page }) {
+    const response = await this.$axios.$get(`/api/jobs/pages/${page}`)
     const data = []
     response.forEach(function (item) {
       data.push(flattenObject(item))


### PR DESCRIPTION
~~WIP because I need to test backwards compatibility with the concourse pipeline. But fairly confident it will behave similarly to before.~~
Tested that the concourse resource still picks up jobs with the change to the endpoint locally using concourse 4.2.2. The only issue that could be presented is if we started >limit jobs in between the check intervals of concourse. However, this was always the case. This PR does reduce the limit to 50, though.

An important note, the `/jobs/` endpoint was kept for backwards compatibility with our concourse pipeline, but all it does now is return the first page of results, which technically is the same behaviour as before, but just reads a different way semantically.