### PR TITLE
add Vagrantfile and shell provisioning

### DIFF
--- a/backend/app/tests/performance/Vagrantfile
+++ b/backend/app/tests/performance/Vagrantfile
@@ -1,0 +1,14 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "bento/ubuntu-18.04"
+  config.vm.network "forwarded_port", guest: 8089, host: 9089
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 1536
+  end
+  config.vm.provision "shell", path: "vagrant.sh"
+end

--- a/backend/app/tests/performance/vagrant.sh
+++ b/backend/app/tests/performance/vagrant.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -ex
+apt-get update -y
+apt-get install -y python-dev python-pip git-core dnsmasq
+git config --global credential.helper cache
+# optimize TCP/IP settings for massive load testing
+echo 'net.core.somaxconn=65535' >> /etc/sysctl.conf
+echo 'net.ipv4.tcp_max_syn_backlog=65535' >> /etc/sysctl.conf
+echo 'fs.file-max=65535' >> /etc/sysctl.conf
+sysctl -p
+sed -i "s/#define NR_OPEN.*/#define NR_OPEN        65536/g" /usr/include/linux/limits.h
+echo '*       soft    nofile      65536' >> /etc/security/limits.conf
+echo '*       hard    nofile      65536' >> /etc/security/limits.conf
+# setup local DNS cache: http://community.linuxmint.com/tutorial/view/489
+sed -i "s/#listen-address=/listen-address=127\.0\.0\.1/g" /etc/dnsmasq.conf
+sed -i "s/#prepend domain-name-servers 127\.0\.0\.1;/prepend domain-name-servers 127\.0\.0\.1;/g" /etc/dhcp/dhclient.conf
+sed -i "s/#require subnet-mask, domain-name-servers;/require subnet-mask, domain-name-servers;/g" /etc/dhcp/dhclient.conf
+sed -i "s/#timeout 60;/timeout 60;/g" /etc/dhcp/dhclient.conf
+sed -i "s/#retry 60;/retry 60;/g" /etc/dhcp/dhclient.conf
+sed -i "s/#reboot 10;/reboot 10;/g" /etc/dhcp/dhclient.conf
+sed -i "s/#select-timeout 5;/select-timeout 5;/g" /etc/dhcp/dhclient.conf
+sed -i "s/#initial-interval 2;/initial-interval 2;/g" /etc/dhcp/dhclient.conf
+/etc/init.d/dnsmasq restart
+cd /vagrant
+pip install -r requirements.txt


### PR DESCRIPTION
This Vagrant environment makes sure that when you loadtest with locust you are:

- not restricted by local connection limits (like desktop mac/linux often have).
- using a DNS cache for requests so you are not load testing the DNS.

Instructions on how to use:
```
vagrant up
vagrant ssh
cd /vagrant
```

Then follow the instructions of the locust loadtesting [README](https://github.com/openstax/output-producer-service/blob/master/backend/app/tests/performance/README.md) but use http://localhost:9089 for opening the UI.

Known issues:
* This is WIP and using Python2 (wrong). You need to upgrade to Python3 in `vagrant.sh` for installation. Locust does not work with Python2 anymore.
* A docker version would be better.