### PR TITLE
Fix integration tests by adding wait-for on the db container before running db setup commands

### DIFF
--- a/docker-compose.tests.yml
+++ b/docker-compose.tests.yml
@@ -9,16 +9,11 @@ services:
     command: bash -c "while true; do sleep 1; done"
     env_file:
       - env-backend.env
-    environment:
+    environment: &testenv
       - SERVER_NAME=backend
-      - PG_HOST=db
-      - PG_USER=postgres
-      - PG_PASSWORD=
-      - PG_DBNAME=tests
+      - POSTGRES_SERVER=db
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=
+      - POSTGRES_DB=tests
   backend:
-    environment:
-      - SERVER_NAME=backend
-      - PG_HOST=db
-      - PG_USER=postgres
-      - PG_PASSWORD=
-      - PG_DBNAME=tests
+    environment: *testenv

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -28,6 +28,7 @@ docker-compose \
 docker-compose -f docker-stack.yml build
 docker-compose -f docker-stack.yml down -v --remove-orphans # Remove possibly previous broken stacks left hanging after an error
 docker-compose -f docker-stack.yml up -d
+docker-compose -f docker-stack.yml exec backend-tests wait-for-it -t 10 db:5432
 docker-compose -f docker-stack.yml exec db psql -h db -d postgres -U postgres -c "DROP DATABASE IF EXISTS tests"
 docker-compose -f docker-stack.yml exec db psql -h db -d postgres -U postgres -c "CREATE DATABASE tests ENCODING 'UTF8'"
 docker-compose -f docker-stack.yml exec -T backend-tests ./bin/tests-start.sh


### PR DESCRIPTION
* Add wait-for for db container on environment setup.
* Practice DRY for db config by using yaml group in docker-compose.tests.yml.