### PR TITLE
Extend load testing for COPS backend

### DIFF
--- a/backend/app/tests/performance/README.md
+++ b/backend/app/tests/performance/README.md
@@ -5,35 +5,24 @@ Load tests for COPS.
 
 **Warning:** Be very careful before testing any production URLs! Speak with your team before doing so.
 
-## Installation
+## Setup
 
-<!-- TODO: Docker or Vagrant install -->
-
-Installation for development purposes:
-
-* Use Python3.
-* Create and activate a virtualenv.
-* Install requirements with `pip install -r requirements.txt`.
+There is a `docker-compose.loadtests.yml` file which can be used to bring up the load testing environment in a stack configuration. You can simply add the file to your invocation of `docker-compose`, and the configuration will add `locust` and `dnsmasq` services to your environment.
 
 ## How to run load tests
 
-To run e.g. the backend jobs load test on localhost use:
-```
-locust -f backendjobs.py --host http://localhost:5001
-```
+[Locust](https://locust.io/) provides a UI that can be used to run backend load tests and view results. The interface can be reached using port `8089` in your browser: [http://localhost:8089](http://localhost:8089)
 
-and open the locust UI in your browser:   
-[http://localhost:8089](http://localhost:8089)
+By default the load test will target the local Docker host service via `http://backend`, but you can modify this URL to target other environments such as staging.
 
-To start a very simple load test set  
-**users** to `100`  
-and  
+To start a very simple load test set
+**users** to `100`
+and
 **hatch** rate to `10`
 
 Start running the load test and see the result in your browser! :)
 
 ## Known issues
 
-* Missing optimized Docker or Vagrant VM
-
-This load tests on your local machine are very simple for development purposes. To run a more demanding "smoke" test 🔥 this load tests need to be run inside an optimized Vagrant VM or Docker with optimized internal network settings and DNS caching (to not load test the DNS query).
+* Load testing non-`GET` requests
+* Distributed load testing

--- a/backend/app/tests/performance/backendjobs.py
+++ b/backend/app/tests/performance/backendjobs.py
@@ -13,9 +13,17 @@ class UserBehavior(TaskSet):
         """ login user """
         pass
 
-    @task
-    def getjobs(self):
+    @task(1)
+    def get_jobs(self):
         self.client.get("/api/jobs/")
+
+    @task(1)
+    def get_status(self):
+        self.client.get("/api/status/")
+
+    @task(1)
+    def get_content_servers(self):
+        self.client.get("/api/content-servers/")
 
 class WebsiteUser(HttpLocust):
     task_set = UserBehavior

--- a/backend/app/tests/performance/dnsmasq.dockerfile
+++ b/backend/app/tests/performance/dnsmasq.dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:latest
+
+LABEL maintainer="OpenStax Content Engineering"
+
+RUN apk --no-cache add dnsmasq
+VOLUME /etc/dnsmasq
+EXPOSE 53 53/udp
+
+ENTRYPOINT ["dnsmasq", "-k"]

--- a/docker-compose.loadtests.yml
+++ b/docker-compose.loadtests.yml
@@ -1,0 +1,35 @@
+version: '3.7'
+services:
+  dnsmasq:
+    build:
+      context: ./backend/app/tests/performance
+      dockerfile: dnsmasq.dockerfile
+    cap_add:
+      - NET_ADMIN
+    networks:
+      net_services:
+        ipv4_address: 172.31.254.10
+  locust:
+    image: locustio/locust
+    environment:
+      LOCUSTFILE_PATH: /code/backendjobs.py
+      TARGET_URL: http://backend
+    ports:
+    - published: 8089
+      target: 8089
+    networks:
+      - default
+      - net_services
+    volumes:
+    - ./backend/app/tests/performance:/code
+    sysctls:
+      net.core.somaxconn: 65535
+      net.ipv4.tcp_max_syn_backlog: 65535
+    dns:
+      - 172.31.254.10
+networks:
+  net_services:
+    ipam:
+      driver: default
+      config:
+      - subnet: 172.31.254.0/24


### PR DESCRIPTION
Update the Locust performance testing implementation to:

- Use Docker for underlying services
- Add load tests for GET endpoints