### PR TITLE
Add Docker logging options to limit disk usage

### DIFF
--- a/docker-compose.deploy.logging.yml
+++ b/docker-compose.deploy.logging.yml
@@ -1,0 +1,22 @@
+version: "3.7"
+services:
+  proxy:
+    logging:
+      options:
+        max-size: "200m"
+        max-file: "5"
+  frontend:
+    logging:
+      options:
+        max-size: "200m"
+        max-file: "5"
+  backend:
+    logging:
+      options:
+        max-size: "200m"
+        max-file: "5"
+  db:
+    logging:
+      options:
+        max-size: "200m"
+        max-file: "5"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -23,6 +23,7 @@ docker-compose \
 -f docker-compose.deploy.networks.yml \
 -f docker-compose.deploy.volumes-placement.yml \
 -f docker-compose.deploy.settings.yml \
+-f docker-compose.deploy.logging.yml \
 config > docker-stack.yml
 
 docker-auto-labels docker-stack.yml


### PR DESCRIPTION
To address disk storage capacity issues observed in production, we're
adding options to manage logs using max-size and max-file flags in
service definitions.