### PR TITLE
Add interim lookUpFeed task definition to bakery

### DIFF
--- a/bakery/src/tasks/look-up-feed.js
+++ b/bakery/src/tasks/look-up-feed.js
@@ -1,0 +1,34 @@
+const dedent = require('dedent')
+
+const task = () => {
+  return {
+    task: 'look up feed',
+    config: {
+      platform: 'linux',
+      image_resource: {
+        type: 'docker-image',
+        source: {
+          repository: 'openstax/cops-bakery-scripts'
+        }
+      },
+      inputs: [{ name: 's3-feed' }],
+      outputs: [{ name: 'book' }],
+      run: {
+        path: '/bin/bash',
+        args: [
+          '-cxe',
+          dedent`
+          exec 2> >(tee upload-book/stderr >&2)
+          feed=s3-feed/distribution-feed.json
+          echo -n "$(cat $feed | jq -r '.[-1].collection_id')" >book/collection_id
+          echo -n "$(cat $feed | jq -r '.[-1].server')" >book/server
+          echo -n "$(cat $feed | jq -r '.[-1].style')" >book/style
+          echo -n "$(cat $feed | jq -r '.[-1].version')" >book/version
+        `
+        ]
+      }
+    }
+  }
+}
+
+module.exports = task


### PR DESCRIPTION
As a precursor towards defining a Distribution Pipeline, we need a
basic placeholder implementation of an ingress task that allows for
defining / triggering jobs. This change adds a simple task definition
which uses an S3 resource as input for this purpose.