### PR TITLE
pin concourse version to 5.8.x for now because 6.0 gives errors with bakery

### DIFF
--- a/docker-compose.dev.images.yml
+++ b/docker-compose.dev.images.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   concourse:
-    image: concourse/concourse
+    image: concourse/concourse:5.8
     privileged: true
   pgadmin:
     image: dpage/pgadmin4


### PR DESCRIPTION
pin concourse version to 5.8.x for now because 6.0 gives errors with bakery