### PR TITLE
Update backend test configuration to run locally

### DIFF
--- a/backend/app/bin/tests-start.sh
+++ b/backend/app/bin/tests-start.sh
@@ -1,4 +1,0 @@
-#! /usr/bin/env bash
-set -e
-
-wait-for-it -t 10 backend:80 -- pytest ./tests -vvv

--- a/backend/app/setup.cfg
+++ b/backend/app/setup.cfg
@@ -1,0 +1,2 @@
+[tool:pytest]
+sensitive_url=^(?:https?:\/\/)?cops\.openstax\.org

--- a/scripts/tests.local.sh
+++ b/scripts/tests.local.sh
@@ -31,4 +31,5 @@ docker-compose -f docker-stack.yml up -d
 docker-compose -f docker-stack.yml exec backend-tests wait-for-it -t 10 db:5432
 docker-compose -f docker-stack.yml exec db psql -h db -d postgres -U postgres -c "DROP DATABASE IF EXISTS tests"
 docker-compose -f docker-stack.yml exec db psql -h db -d postgres -U postgres -c "CREATE DATABASE tests ENCODING 'UTF8'"
-docker-compose -f docker-stack.yml exec -T backend-tests ./bin/tests-start.sh
+docker-compose -f docker-stack.yml exec backend-tests wait-for-it -t 10 backend:80
+docker-compose -f docker-stack.yml exec -T backend-tests pytest ./tests -vvv -m "ui or integration" --junitxml="${TEST_RESULTS}" --driver Chrome --base-url http://frontend --headless


### PR DESCRIPTION
 This change fixes two issues:
    
 * The `tests.local.sh` script was failing due to missing arguments to
  `pytest` needed for the UI tests. That is updated to use the same
  invocation as `test.ci.sh` and the `tests-start.sh` deleted.
* The `test_jobs_post_request_successful` test was being skipped due
  to it being configured as a destructive test. We can add a setup.cfg
  file that specifies sensitive URLs so this test gets run locally and
  in CI.