### PR TITLE
Support disassembled ToC linking

### DIFF
--- a/bakery/.gitignore
+++ b/bakery/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 src/tests/output/
+**/__pycache__/

--- a/bakery/README.md
+++ b/bakery/README.md
@@ -17,6 +17,8 @@ To use the CLI, you must have all of the following already installed:
 - node >= 12.16.1
 - npm
 - concourse `fly` CLI
+    1. [install concourse locally](https://concoursetutorial.com/#getting-started)
+    1. download `fly` from http://localhost:8080 and add it to your path
 
 getting the above software installed is outside the scope of this documentation.
 
@@ -98,8 +100,8 @@ For example, if one wanted to make changes to cops-bakery-scripts and have those
 1. Have `src/scripts` as your working directory
 2. Make the desired change in the `src/scripts/*.py` file
 3. Build the image with `docker build .`
-4. Tag the build image as `localhost.localdomain:5000/openstax/cops-bakery/scripts:latest` (the prefix of `localhost.localdomain:5000` is *required*, what you name and tag your image is up to you), for example, with `docker tag $(docker image ls | awk 'NR==2 {print $3}') localhost.localdomain:5000/openstax/cops-bakery/scripts:latest`
-5. Run the desired pipeline step with the CLI with the `--image` flag, e.g. `node ./src/cli/execute.js assemble-meta --image localhost.localdomain:5000/openstax/cops-bakery-scripts -c ./.. -d /tmp/data col30149`
+4. Tag the build image as `localhost.localdomain:5000/openstax/cops-bakery/scripts:latest` (the prefix of `localhost.localdomain:5000` is *required*, what you name and tag your image is up to you), for example, with `docker tag $(docker image ls | awk 'NR==2 {print $3}') localhost.localdomain:5000/openstax/cops-bakery-scripts:latest`
+5. Run the desired pipeline step with the CLI with the `--image` flag, e.g. `node ./src/cli/execute.js assemble-meta --image localhost.localdomain:5000/openstax/cops-bakery-scripts:latest -c ./.. -d /tmp/data col30149`
 
 Note: Using a local docker image as a task's `image_resource` is only supported for the `assemble-meta`, `bake-meta`, `disassemble`, and `jsonify` steps for now, to allow for local development.
 

--- a/bakery/src/cli/execute.js
+++ b/bakery/src/cli/execute.js
@@ -191,7 +191,7 @@ const flyExecute = async (cmdArgs, { image, persist }) => {
     }
     error = err
   } finally {
-    if (error != null || !persist) {
+    if (!persist) {
       console.log('cleaning up')
       const cleanUp = spawn('docker-compose', [
         '-f', tmpComposeYml.name,

--- a/bakery/src/cli/execute.js
+++ b/bakery/src/cli/execute.js
@@ -521,6 +521,7 @@ const yargs = require('yargs')
       await flyExecute([
         '-c', tmpTaskFile.name,
         `--input=book=${tmpBookDir.name}`,
+        input(dataDir, 'fetched-book'),
         input(dataDir, 'baked-book'),
         input(dataDir, 'baked-book-metadata'),
         output(dataDir, 'disassembled-book')

--- a/bakery/src/scripts/Dockerfile
+++ b/bakery/src/scripts/Dockerfile
@@ -2,8 +2,7 @@ FROM python:3.7-stretch
 
 LABEL maintainer="OpenStax Content Engineering"
 
-COPY ./*.py /code/scripts/
-COPY ./requirements.txt /code
+COPY ./requirements.txt /code/
 WORKDIR /code/
 
 RUN pip install -r requirements.txt
@@ -20,3 +19,5 @@ RUN wget --no-check-certificate https://raw.githubusercontent.com/stedolan/jq/ma
     rm -f /tmp/jq-release.key && \
     rm -f /tmp/jq-linux64.asc && \
     rm -f /tmp/jq-linux64
+
+COPY ./*.py /code/scripts/

--- a/bakery/src/scripts/disassemble-book.py
+++ b/bakery/src/scripts/disassemble-book.py
@@ -65,7 +65,7 @@ def main():
     nav_links = toc.xpath("//xhtml:a", namespaces=HTML_DOCUMENT_NAMESPACES)
 
     for doc in flatten_to_documents(binder):
-        id_with_context = f'{collection_uuid}@{collection_version}:{doc.ident_hash}'
+        id_with_context = f'{collection_uuid}@{collection_version}:{doc.id}'
 
         module_etree = content_to_etree(doc.content)
         for link in nav_links:

--- a/bakery/src/task.js
+++ b/bakery/src/task.js
@@ -31,11 +31,7 @@ module.exports.builder = yargs => {
 module.exports.handler = argv => {
   const task = (() => {
     const taskFilePath = path.resolve(taskDir, `${argv.taskname}.js`)
-    try {
-      return require(taskFilePath)
-    } catch {
-      throw new Error(`Could not find task file: ${taskFilePath}`)
-    }
+    return require(taskFilePath)
   })()
   const outputFile = argv.output == null
     ? undefined

--- a/bakery/src/tasks/disassemble-book.js
+++ b/bakery/src/tasks/disassemble-book.js
@@ -16,6 +16,7 @@ const task = ({ imageRegistry, imageName, imageTag }) => {
       },
       inputs: [
         { name: 'book' },
+        { name: 'fetched-book' },
         { name: 'baked-book' },
         { name: 'baked-book-metadata' }
       ],
@@ -27,11 +28,14 @@ const task = ({ imageRegistry, imageName, imageTag }) => {
           dedent`
           exec 2> >(tee disassembled-book/stderr >&2)
           collection_id="$(cat book/collection_id)"
+          book_metadata="fetched-book/$collection_id/raw/metadata.json"
+          book_uuid="$(cat $book_metadata | jq -r '.id')"
+          book_version="$(cat $book_metadata | jq -r '.version')"
           cp -r baked-book/* disassembled-book
           cp "baked-book-metadata/$collection_id/collection.baked-metadata.json" "disassembled-book/$collection_id/collection.baked-metadata.json"
           book_dir="disassembled-book/$collection_id"
           mkdir "$book_dir/disassembled"
-          python /code/scripts/disassemble-book.py "$book_dir" "$collection_id"
+          python /code/scripts/disassemble-book.py "$book_dir" "$book_uuid" "$book_version"
         `
         ]
       }

--- a/bakery/src/tasks/upload-book.js
+++ b/bakery/src/tasks/upload-book.js
@@ -35,8 +35,8 @@ const task = ({ awsAccessKeyId, awsSecretAccessKey, bucketName }) => {
           book_version="$(cat $book_metadata | jq -r '.version')"
           cp "$book_dir/collection.toc.json" "$target_dir/$book_uuid@$book_version.json"
           cp "$book_dir/collection.toc.xhtml" "$target_dir/$book_uuid@$book_version.xhtml"
-          for jsonfile in "$book_dir/"*@*.json; do cp "$jsonfile" "$target_dir/$book_uuid@$book_version:$(basename $jsonfile)"; done;
-          for xhtmlfile in "$book_dir/"*@*.xhtml; do cp "$xhtmlfile" "$target_dir/$book_uuid@$book_version:$(basename $xhtmlfile)"; done;
+          for jsonfile in "$book_dir/"*@*.json; do cp "$jsonfile" "$target_dir/$(basename $jsonfile)"; done;
+          for xhtmlfile in "$book_dir/"*@*.xhtml; do cp "$xhtmlfile" "$target_dir/$(basename $xhtmlfile)"; done;
           aws s3 cp --recursive "$target_dir" s3://${bucketName}/contents
         `
         ]

--- a/bakery/src/tests/test_bakery_scripts.py
+++ b/bakery/src/tests/test_bakery_scripts.py
@@ -23,14 +23,18 @@ def test_jsonify_book(tmp_path):
         "slug": "1-3-subsection-slug"
     }
 
+    mock_uuid = "00000000-0000-0000-0000-000000000000"
+    mock_version = "0.0"
+    mock_ident_hash = f"{mock_uuid}@{mock_version}"
+
     disassembled_input_dir = tmp_path / "disassembled"
     disassembled_input_dir.mkdir()
 
-    xhtml_input = disassembled_input_dir / "m00001@1.1.xhtml"
+    xhtml_input = disassembled_input_dir / f"{mock_ident_hash}:m00001.xhtml"
     xhtml_input.write_text(html_content)
     toc_input = disassembled_input_dir / "collection.toc.xhtml"
     toc_input.write_text(toc_content)
-    json_metadata_input = disassembled_input_dir / "m00001@1.1-metadata.json"
+    json_metadata_input = disassembled_input_dir / f"{mock_ident_hash}:m00001-metadata.json"
     json_metadata_input.write_text(json.dumps(json_metadata_content))
 
     jsonified_output_dir = tmp_path / "jsonified"
@@ -47,7 +51,7 @@ def test_jsonify_book(tmp_path):
         check=True
     )
 
-    jsonified_output = jsonified_output_dir / "m00001@1.1.json"
+    jsonified_output = jsonified_output_dir / f"{mock_ident_hash}:m00001.json"
     jsonified_output_data = json.loads(jsonified_output.read_text())
     jsonified_toc_output = jsonified_output_dir / "collection.toc.json"
     jsonified_toc_data = json.loads(jsonified_toc_output.read_text())
@@ -97,8 +101,8 @@ def test_disassemble_book(tmp_path):
     assert len(json_output_files) == 3
 
     # Check for expected files and metadata that should be generated in this step
-    json_output_m42119 = disassembled_output / f"{mock_ident_hash}:m42119@1.6-metadata.json"
-    json_output_m42092 = disassembled_output / f"{mock_ident_hash}:m42092@1.10-metadata.json"
+    json_output_m42119 = disassembled_output / f"{mock_ident_hash}:m42119-metadata.json"
+    json_output_m42092 = disassembled_output / f"{mock_ident_hash}:m42092-metadata.json"
     m42119_data = json.load(open(json_output_m42119, "r"))
     m42092_data = json.load(open(json_output_m42092, "r"))
     assert m42119_data.get("title") == \
@@ -151,8 +155,8 @@ def test_disassemble_book_empy_baked_metadata(tmp_path):
     )
 
     # Check for expected files and metadata that should be generated in this step
-    json_output_m42119 = disassembled_output / f"{mock_ident_hash}:m42119@1.6-metadata.json"
-    json_output_m42092 = disassembled_output / f"{mock_ident_hash}:m42092@1.10-metadata.json"
+    json_output_m42119 = disassembled_output / f"{mock_ident_hash}:m42119-metadata.json"
+    json_output_m42092 = disassembled_output / f"{mock_ident_hash}:m42092-metadata.json"
     m42119_data = json.load(open(json_output_m42119, "r"))
     m42092_data = json.load(open(json_output_m42092, "r"))
     assert m42119_data["abstract"] is None

--- a/bakery/src/tests/test_bakery_scripts.py
+++ b/bakery/src/tests/test_bakery_scripts.py
@@ -63,7 +63,6 @@ def test_disassemble_book(tmp_path):
     disassemble_book_script = os.path.join(SCRIPT_DIR, "disassemble-book.py")
     input_baked_xhtml = os.path.join(TEST_DATA_DIR, "collection.baked.xhtml")
     input_baked_metadata = os.path.join(TEST_DATA_DIR, "collection.baked-metadata.json")
-    input_baked_collection_id = os.path.join(TEST_DATA_DIR, "collection_id")
 
     input_dir = tmp_path / "book"
     input_dir.mkdir()
@@ -72,17 +71,21 @@ def test_disassemble_book(tmp_path):
     input_baked_xhtml_file.write_bytes(open(input_baked_xhtml, "rb").read())
     input_baked_metadata_file = input_dir / "collection.baked-metadata.json"
     input_baked_metadata_file.write_text(open(input_baked_metadata, "r").read())
-    collection_id = open(input_baked_collection_id, "r").read()
 
     disassembled_output = input_dir / "disassembled"
     disassembled_output.mkdir()
+
+    mock_uuid = "00000000-0000-0000-0000-000000000000"
+    mock_version = "0.0"
+    mock_ident_hash = f"{mock_uuid}@{mock_version}"
 
     subprocess.run(
         [
             "python",
             disassemble_book_script,
             input_dir,
-            collection_id
+            mock_uuid,
+            mock_version
         ],
         cwd=HERE,
         check=True
@@ -94,8 +97,8 @@ def test_disassemble_book(tmp_path):
     assert len(json_output_files) == 3
 
     # Check for expected files and metadata that should be generated in this step
-    json_output_m42119 = disassembled_output / "m42119@1.6-metadata.json"
-    json_output_m42092 = disassembled_output / "m42092@1.10-metadata.json"
+    json_output_m42119 = disassembled_output / f"{mock_ident_hash}:m42119@1.6-metadata.json"
+    json_output_m42092 = disassembled_output / f"{mock_ident_hash}:m42092@1.10-metadata.json"
     m42119_data = json.load(open(json_output_m42119, "r"))
     m42092_data = json.load(open(json_output_m42092, "r"))
     assert m42119_data.get("title") == \
@@ -119,7 +122,6 @@ def test_disassemble_book_empy_baked_metadata(tmp_path):
     """
     disassemble_book_script = os.path.join(SCRIPT_DIR, "disassemble-book.py")
     input_baked_xhtml = os.path.join(TEST_DATA_DIR, "collection.baked.xhtml")
-    input_baked_collection_id = os.path.join(TEST_DATA_DIR, "collection_id")
 
     input_dir = tmp_path / "book"
     input_dir.mkdir()
@@ -127,26 +129,30 @@ def test_disassemble_book_empy_baked_metadata(tmp_path):
     input_baked_xhtml_file = input_dir / "collection.baked.xhtml"
     input_baked_xhtml_file.write_bytes(open(input_baked_xhtml, "rb").read())
     input_baked_metadata_file = input_dir / "collection.baked-metadata.json"
-    collection_id = open(input_baked_collection_id, "r").read()
     input_baked_metadata_file.write_text(json.dumps({}))
 
     disassembled_output = input_dir / "disassembled"
     disassembled_output.mkdir()
+
+    mock_uuid = "00000000-0000-0000-0000-000000000000"
+    mock_version = "0.0"
+    mock_ident_hash = f"{mock_uuid}@{mock_version}"
 
     subprocess.run(
         [
             "python",
             disassemble_book_script,
             input_dir,
-            collection_id
+            mock_uuid,
+            mock_version
         ],
         cwd=HERE,
         check=True
     )
 
     # Check for expected files and metadata that should be generated in this step
-    json_output_m42119 = disassembled_output / "m42119@1.6-metadata.json"
-    json_output_m42092 = disassembled_output / "m42092@1.10-metadata.json"
+    json_output_m42119 = disassembled_output / f"{mock_ident_hash}:m42119@1.6-metadata.json"
+    json_output_m42092 = disassembled_output / f"{mock_ident_hash}:m42092@1.10-metadata.json"
     m42119_data = json.load(open(json_output_m42119, "r"))
     m42092_data = json.load(open(json_output_m42092, "r"))
     assert m42119_data["abstract"] is None


### PR DESCRIPTION
The linking works by checking each module for a top-level id that matches
an href in the ToC. Additionally, disassembled files now have the format of
collection_id@version:page_id, since the information was needed for 
correct linking, and we formatted names like that on the upload step
anyways. i.e. the formatting takes place in disassembly now, rather than in
upload.

As an extra, this includes a change to the cops-bakery-scripts Dockerfile that takes better advantage of layer caching.