### PR TITLE
Improve CLI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,12 @@ jobs:
 
     steps:
       - checkout
+
+      - run:
+          name: Setup localdomain
+          command: |
+            sudo sed -i 's/localhost/localhost localhost.localdomain/g' /etc/hosts
+
       - run:
           name: Install node
           command: |

--- a/bakery/src/cli/execute.js
+++ b/bakery/src/cli/execute.js
@@ -40,11 +40,13 @@ const extractImageDetails = imageArg => {
     imageName = imageArgStripped.slice(0, tagNameSeparatorIndex)
     imageTag = imageArgStripped.slice(tagNameSeparatorIndex + 1)
   }
-  return {
+  const details = {
     imageRegistry: 'registry:5000',
     imageName,
     imageTag
   }
+  console.log(`extracted image details: ${JSON.stringify(details)}`)
+  return details
 }
 
 const input = (dataDir, name) => `--input=${name}=${dataDir}/${name}`
@@ -249,7 +251,7 @@ const yargs = require('yargs')
         })
       },
       handler: argv => {
-        handler(argv).catch((err) => { console.error(err) })
+        handler(argv).catch((err) => { console.error(err); process.exit(1) })
       }
     }
   }).call())
@@ -286,7 +288,7 @@ const yargs = require('yargs')
         })
       },
       handler: argv => {
-        handler(argv).catch((err) => { console.error(err) })
+        handler(argv).catch((err) => { console.error(err); process.exit(1) })
       }
     }
   }).call())
@@ -338,7 +340,7 @@ const yargs = require('yargs')
         })
       },
       handler: argv => {
-        handler(argv).catch((err) => { console.error(err) })
+        handler(argv).catch((err) => { console.error(err); process.exit(1) })
       }
     }
   }).call())
@@ -375,7 +377,7 @@ const yargs = require('yargs')
         })
       },
       handler: argv => {
-        handler(argv).catch((err) => { console.error(err) })
+        handler(argv).catch((err) => { console.error(err); process.exit(1) })
       }
     }
   }).call())
@@ -413,7 +415,7 @@ const yargs = require('yargs')
         })
       },
       handler: argv => {
-        handler(argv).catch((err) => { console.error(err) })
+        handler(argv).catch((err) => { console.error(err); process.exit(1) })
       }
     }
   }).call())
@@ -454,7 +456,7 @@ const yargs = require('yargs')
         })
       },
       handler: argv => {
-        handler(argv).catch((err) => { console.error(err) })
+        handler(argv).catch((err) => { console.error(err); process.exit(1) })
       }
     }
   }).call())
@@ -496,7 +498,7 @@ const yargs = require('yargs')
         })
       },
       handler: argv => {
-        handler(argv).catch((err) => { console.error(err) })
+        handler(argv).catch((err) => { console.error(err); process.exit(1) })
       }
     }
   }).call())
@@ -539,7 +541,7 @@ const yargs = require('yargs')
         })
       },
       handler: argv => {
-        handler(argv).catch((err) => { console.error(err) })
+        handler(argv).catch((err) => { console.error(err); process.exit(1) })
       }
     }
   }).call())
@@ -580,7 +582,7 @@ const yargs = require('yargs')
         })
       },
       handler: argv => {
-        handler(argv).catch((err) => { console.error(err) })
+        handler(argv).catch((err) => { console.error(err); process.exit(1) })
       }
     }
   }).call())

--- a/bakery/src/cli/execute.js
+++ b/bakery/src/cli/execute.js
@@ -146,25 +146,25 @@ const flyExecute = async (cmdArgs, { image, persist }) => {
       output: 'silent'
     })
 
+    console.log('syncing')
+    const sync = spawn('fly', [
+      'sync',
+      '-c', 'http://localhost.localdomain:8080'
+    ], { stdio: 'inherit' })
+    children.push(sync)
+    await completion(sync)
+
     console.log('logging in')
     const login = spawn('fly', [
       'login',
       '-k',
       '-t', 'bakery-cli',
-      '-c', 'http://127.0.0.1:8080',
+      '-c', 'http://localhost.localdomain:8080',
       '-u', 'admin',
       '-p', 'admin'
     ], { stdio: 'inherit' })
     children.push(login)
     await completion(login)
-
-    console.log('syncing')
-    const sync = spawn('fly', [
-      'sync',
-      '-t', 'bakery-cli'
-    ], { stdio: 'inherit' })
-    children.push(sync)
-    await completion(sync)
 
     console.log('waiting for concourse to settle')
     await sleep(5000)

--- a/bakery/src/tests/data/col30149-recipe.css
+++ b/bakery/src/tests/data/col30149-recipe.css
@@ -1,0 +1,2124 @@
+/*
+  Book Page
+
+  A Page is usually a section inside a chapter. It contains:
+
+  - `[data-type='metadata']` The attribution information for this Page
+  - `[data-type='document-title']` The title of the Page
+
+  Markup: ./book.page.xhtml-baked.html
+
+  Style guide: book.1-page
+*/
+/*
+  Page Title
+
+  Page titles may be overwritten in collection. In such case the collection-set
+  title should be used.
+
+  Markup: ./book.page.title.xhtml-baked.html
+
+  Style guide: book.1-page-title
+*/
+/*
+  Page Elements
+
+  Everything in here is specific to a Page in a book.
+  A Page is usually a section inside a chapter.
+
+  Style guide: page
+*/
+/*
+  Metadata
+
+  This contains attribution information and is sometimes collated to the back of the book.
+
+  Markup:
+  <div data-type="page">
+    <div data-type="metadata">...</div>
+  </div>
+
+  Style guide: page.0-metadata
+*/
+/*
+  Processing Instruction
+
+  These are an artifact of the transforms and will disappear in the future
+
+  Markup:
+  <div data-type="page">
+    <cnx-pi />
+  </div>
+
+  Style guide: page.0-processing
+*/
+/*
+  Term
+
+  A term which is used to make the Book Index. Terms used in a Glossary are defined in the Glossary, not here.
+
+  Markup: ./page.term.xhtml-baked.html
+
+  Style guide: page.term
+*/
+/*
+  Note
+
+  A note or "feature". This is usually separated visually from the rest of the
+  content in a book with a border and a separate background color.
+
+  Contains an optional title, and optionally an additional class to help style the note
+
+  Markup: ./page.note.xhtml-baked.html
+
+  Style guide: page.note
+*/
+/*
+  Figure
+
+  A `<figure>` is wrapped in a `<div data-type='figure'>` which contains:
+  - optional `[data-type='title']`
+  - `figure` element
+    - `[data-type='media']` : a wrapper element which may disappear in the future
+      - `img[src][alt]` : The image for the Figure
+
+  TODO: Maybe this should use the `<picture>` element instead of the `[data-type='media']` element:
+  http://html5rocks.com/en/tutorials/responsive/picture-element/
+
+  # TODO
+
+  - Decide on what the baked markup for a figure with a title and caption should look like.
+    - Proposals have mentioned using `<figcaption>` most of the time.
+    - Maybe what is in the Raw HTML is _good enough_?
+
+  Markup: ./page.figure.xhtml-baked.html
+
+  Style guide: page.figure
+*/
+/*
+  Paragraph
+
+  A Paragraph of text. Some of the common things it can contain are:
+
+  - `[data-type='term']` : A term that is defined elsewhere (in the glossary)
+  - `strong`
+  - `em`
+  - `[data-type='list']` : an inline list
+    - `[data-type='item']` : an item in the list
+  - `math` : MathML
+
+  TODO: Move these into a separate "inline" section in the HTML guide
+
+  Markup: ./page.para.xhtml-baked.html
+
+  Style guide: page.para
+*/
+/*
+  Section
+
+  A (sub)section of content which contains a title.
+
+  Markup: ./page.section.xhtml-baked.html
+
+  Style guide: page.section
+*/
+/*
+  Example
+
+  An example which is usually styled to not be part of the flow of normal content
+  (similar to a Note).
+
+  Markup: ./page.example.xhtml-baked.html
+
+  Style guide: page.example
+*/
+/*
+  Exercise
+
+  An exercise contains a problem, optional title, and optional solution(s).
+
+  Exercises are usually numbered and contain a link to the solution if it exists.
+  Typically, an exercise is collated at the end of chapter.
+
+  Solutions are collated (at the end of section, end of chapter or end of book), they are numbered (the number is the same as the exercise they are associated to) and link back to their exercise.
+
+  Markup: ./page.exercise.xhtml-baked.html
+
+  Style guide: page.exercise
+*/
+/*
+  Equation
+
+  An equation wraps a MathML formula and is usually numbered.
+
+  Markup: ./page.equation.xhtml-baked.html
+
+  Style guide: page.equation
+*/
+/*
+  Glossary
+
+  This element is often referred to as Key Terms in the textbook.
+  It is collated as a separate Page at the end of a Chapter or a Book.
+  Also, it is collected from individual glossary elements in each raw Page.
+
+  Markup: ./book.glossary.xhtml-baked.html
+
+  Style guide: book.glossary
+*/
+/*
+  Book Index
+
+  The book Index contains terms and links to their occurences in the book.
+
+  Markup: ./book.index.xhtml-baked.html
+
+  Style guide: book.index
+*/
+/*
+  Table
+
+  The `table` element may contain a `caption`, `tbody`, `col`, and other _usual_ elements.
+
+  If the table contains a title, there is an additional element inside `<caption>`
+
+  # TODO
+
+  - Decide on what the baked markup for a table with a title and caption should look like.
+    - Proposals have mentioned wrapping the `<table>` element with a `.os-table-container` element.
+    - Maybe what is in the Raw HTML is _good enough_?
+
+  Markup: ./page.table.xhtml-baked.html
+
+  Style guide: page.table
+*/
+/*
+  Composite Page
+
+  These are end-of-book or end-of-chapter Pages.
+
+  A Composite Page is one that is automatically generated by moving/copying content from the raw pages.
+  Examples include the end-of-chapter exercises, end-of-book solutions, end-of-chapter glossary, index.
+
+  They:
+
+  - must use data-type="composite-page".
+  - must have a unique identifier (class) for styling purposes.
+  - usually contain content separated by section(pages) or by chapter.
+  - now appear in the TOC (currently not the case in the PDF).
+  - aren't numbered in the content and in the TOC (the chapters and sections are)
+  - follow the same rules as a regular data-type="page" (header hierarchy, metadata, etc.)
+
+  Style guide: book.2-composite
+*/
+/*
+  Book Preface
+
+  A Preface is a Page at the beginning of a book that is not inside a Chapter. It contains:
+
+  - `.preface` A class to identify it as a Preface
+  - `[data-type='metadata']` The attribution information for this Page
+  - `[data-type='document-title']` The title of the Page
+
+  Markup: ./book.preface.xhtml-baked.html
+
+  Style guide: book.1-preface
+*/
+/*
+  Chapter
+
+  A Chapter contains a title and multiple Pages, one of which may be a `.introduction` Page.
+
+  The introduction page typically contains a splash image, a chapter outline and an introductory paragraph.
+
+  Markup: ./book.chapter.xhtml-baked.html
+
+  Style guide: book.0-chapter
+*/
+/*
+  Unit
+
+  A Unit contains a title and multiple Chapters.
+
+  It does not currently contain an "Introduction" Page.
+
+  Markup: ./book.unit.xhtml-baked.html
+
+  Style guide: book.0-unit
+*/
+/*
+  Unnumbered Content
+
+  Content that has been marked with the class `.unnumbered` by the content team.
+
+  Currently, the recipe supports only tables and figures but
+  this may apply to a note, a table, an equation, a figure.
+
+  Markup: ./page.unnumbered.xhtml-baked.html
+
+  Style guide: page.unnumbered
+
+*/
+/*
+  Lists
+
+  Lists can contain a label or title and can be block content or inline.
+
+  Markup: ./page.list.xhtml-baked.html
+
+  Style guide: page.list
+
+*/
+/*
+  Iframe
+
+  An iframe can show an embedded simulation or video. Some formats cannot or would
+  rather not show the iframe and present a link instead.
+
+  So we wrap the element inside a `[data-type="alternatives"]` element and add
+  enough classes to be able to select which alternative to show and which to hide.
+
+  Markup: ./page.iframe.xhtml-baked.html
+
+  Style guide: page.iframe
+*/
+/*
+  Links
+
+  Links to simulations should open in a new tab (ie `<a target="_blank">`)
+
+  Markup: ./page.link.xhtml-baked.html
+
+  Style guide: page.link
+
+*/
+/*==========================================================
+  BUSINESS ETHICS CONFIG
+==========================================================*/
+/*==========================================================
+  Notes
+==========================================================*/
+/*
+/*
+  Link to Learning note
+
+  Contains a title "Link to Learning", a subtitle, and the note body.
+
+  Markup: ./styleguide/page.note.link-to-learning.xhtml-baked.html
+
+  Style guide: page.note.link-to-learning
+*/
+/*
+  Cases from the Real World note
+
+  Contains a title "Cases from the Real World", a subtitle, and the note body.
+
+  Markup: ./styleguide/page.note.real-world.xhtml-baked.html
+
+  Style guide: page.note.real-world
+*/
+/*
+  What Would You Do note
+
+  Contains a title "What Would You Do", a subtitle, and the note body.
+
+  Markup: ./styleguide/page.note.what-would.xhtml-baked.html
+
+  Style guide: page.note.what-would
+*/
+/*
+  Ethics Across Time and Cultures note
+
+  Contains a title "Ethics Across Time and Cultures", a subtitle, and the note body.
+
+  Markup: ./styleguide/page.note.ethics-across.xhtml-baked.html
+
+  Style guide: page.note.ethics-across
+*/
+/*==========================================================
+  EOC
+==========================================================*/
+/*
+  Summary page
+
+  These should be collated at the end of a chapter.
+
+  Markup: ./styleguide/book.composite.section-summary.xhtml-baked.html
+
+  Style guide: book.composite.section-summary
+*/
+/*
+  Key Terms page
+
+  These should be collated at the end of a chapter.
+
+  Markup: ./styleguide/book.composite.key-terms.xhtml-baked.html
+
+  Style guide: book.composite.key-terms
+*/
+/*
+  Assessment Questions page
+
+  These should be collated at the end of a chapter.
+
+  Markup: ./styleguide/book.composite.assessment-questions.xhtml-baked.html
+
+  Style guide: book.composite.assessment-questions
+*/
+/*
+  Endnotes page
+
+  These should be collated at the end of a chapter.
+
+  Markup: ./styleguide/book.composite.references.xhtml-baked.html
+
+  Style guide: book.composite.references
+*/
+/*
+  Figure Credits page
+
+  These should be collated at the end of a chapter.
+
+  Markup: ./styleguide/book.composite.figure-credits.xhtml-baked.html
+
+  Style guide: book.composite.figure-credits
+*/
+/*
+  Case Study page
+
+  These should be collated at the end of a chapter.
+
+  Markup: ./styleguide/book.composite.case-study.xhtml-baked.html
+
+  Style guide: book.composite.case-study
+*/
+/*
+  Chapter Objectives note
+
+  This is a Note that appears in the Introduction page of every chapter.
+
+  Markup: ./styleguide/page.note.chapter-objectives.xhtml-baked.html
+
+  Style guide: page.note.chapter-objectives
+*/
+@namespace xhtml "http://www.w3.org/1999/xhtml";
+@namespace cmlnle "http://katalysteducation.org/cmlnle/1.0";
+@namespace cxlxt "http://katalysteducation.org/cxlxt/1.0";
+:pass(0) [data-type='list']:not([data-list-type]),
+:pass(0) [data-type='list'][data-list-type='bulleted'],
+:pass(0) [data-type='list'][data-list-type='enumerated'] {
+  sort-by: 'invalid-namespace-just-to-throw-an-error|element-HACK'; }
+
+:pass(0) [data-type='list'][data-list-type='labeled-item']:not([data-item-sep]) > span[data-type="item"]:not(:last-child)::after,
+:pass(0) [data-type='list'][data-list-type='bulleted']:not([data-item-sep]) > span[data-type="item"]:not(:last-child)::after {
+  container: span;
+  attr-class: "-os-inline-list-separator";
+  content: "; "; }
+
+:pass(0) [data-type='list'][data-list-type='labeled-item'][data-item-sep],
+:pass(0) [data-type='list'][data-list-type='bulleted'][data-item-sep] {
+  string-set: listItemSep attr(data-item-sep); }
+  :pass(0) [data-type='list'][data-list-type='labeled-item'][data-item-sep] > [data-type="item"]:not(:last-child)::after,
+  :pass(0) [data-type='list'][data-list-type='bulleted'][data-item-sep] > [data-type="item"]:not(:last-child)::after {
+    container: span;
+    attr-class: "-os-inline-list-separator";
+    content: string(listItemSep); }
+
+:pass(0) div[data-type="page"] > div[data-type="metadata"] > [data-type="document-title"] {
+  string-set: page-title content(); }
+
+:pass(0) div[data-type="page"] > [data-type="document-title"] {
+  content: string(page-title); }
+
+:pass(1) div.preface > [data-type="document-title"] {
+  container: h1;
+  content: content(); }
+
+:pass(1) :not([data-type="metadata"]) > [data-type="document-title"] {
+  content: ''; }
+  :pass(1) :not([data-type="metadata"]) > [data-type="document-title"]::after {
+    content: content();
+    container: span;
+    class: "os-text"; }
+
+:pass(1) a.os-interactive-link {
+  attr-target: "_blank"; }
+
+:pass(1) [data-type="exercise"][data-label]:not([data-label=""])::after {
+  container: div;
+  class: "os-label";
+  content: attr(data-label);
+  move-to: bTitleLabel; }
+
+:pass(1) [data-type="exercise"][data-label]:not([data-label=""])::outside {
+  data-type: "exercise-container";
+  container: div;
+  content: pending(bTitleLabel) content(); }
+
+:pass(1) [data-type="exercise"] [data-type="problem"]::inside {
+  class: "os-problem-container"; }
+
+:pass(1) [data-type="exercise"] [data-type="solution"]::inside {
+  class: "os-solution-container"; }
+
+:pass(1) ol[data-label]:not([data-label=""])::after,
+:pass(1) ul[data-label]:not([data-label=""])::after {
+  container: div;
+  class: "os-label";
+  content: attr(data-label);
+  move-to: bListLabel; }
+
+:pass(1) ol[data-label]:not([data-label=""])::outside,
+:pass(1) ul[data-label]:not([data-label=""])::outside {
+  data-type: "list-container";
+  container: div;
+  content: pending(bListLabel) content(); }
+
+:pass(1) :not([data-type="alternatives"]) > iframe {
+  class: attr(class) "os-is-iframe"; }
+  :pass(1) :not([data-type="alternatives"]) > iframe::after {
+    container: a;
+    class: "os-is-link";
+    attr-target: "_window";
+    attr-href: attr(src);
+    content: "Click to view content";
+    move-to: bIframeLink; }
+  :pass(1) :not([data-type="alternatives"]) > iframe::outside {
+    container: div;
+    data-type: "alternatives";
+    class: "os-has-iframe os-has-link";
+    content: pending(bIframeLink) content(); }
+
+:pass(1) cnx-pi {
+  move-to: trash; }
+
+:pass(1) :not([data-type="example"]) > [data-type="exercise"] {
+  string-set: isSolution ""; }
+  :pass(1) :not([data-type="example"]) > [data-type="exercise"] [data-type="solution"] {
+    string-set: isSolution " os-hasSolution "; }
+  :pass(1) :not([data-type="example"]) > [data-type="exercise"]::deferred {
+    class: attr(class) string(isSolution, " "); }
+
+:pass(1) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"]:not([class])::inside {
+  class: "os-note-body"; }
+
+:pass(1) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"]:not([class]) > div[data-type="title"] {
+  container: span;
+  class: "os-title-label";
+  data-type: "";
+  move-to: genericNoteLabel; }
+
+:pass(1) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"]:not([class]):deferred::before {
+  container: h3;
+  content: pending(genericNoteLabel);
+  class: "os-title";
+  attr-data-type: "title"; }
+
+:pass(1) [data-type="note"] [data-type="note"]:not([class])::inside {
+  class: "os-note-body"; }
+
+:pass(1) [data-type="note"] [data-type="note"]:not([class]) > div[data-type="title"] {
+  container: span;
+  class: "os-title-label";
+  data-type: "";
+  move-to: genericNoteLabeldepth1; }
+
+:pass(1) [data-type="note"] [data-type="note"]:not([class]):deferred::before {
+  container: h4;
+  content: pending(genericNoteLabeldepth1);
+  class: "os-title";
+  attr-data-type: "title"; }
+
+:pass(1) [data-type="metadata"] > [data-type="description"] {
+  move-to: trash; }
+
+:pass(1) [data-type="exercise"] {
+  string-set: missing ""; }
+  :pass(1) [data-type="exercise"] div.missing-exercise {
+    string-set: missing " missing-exercise"; }
+  :pass(1) [data-type="exercise"]::deferred {
+    class: attr(class) string(missing); }
+
+:pass(1) ol[data-number-style="lower-alpha"] {
+  attr-type: "a"; }
+
+:pass(2) [data-type="exercise"].missing-exercise {
+  move-to: trash; }
+
+:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].link-to-learning > div[data-type="title"]::deferred {
+  container: h4;
+  class: "os-subtitle";
+  move-to: noteSubtitle; }
+
+:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].link-to-learning > div[data-type="title"]::inside {
+  container: span;
+  class: "os-subtitle-label"; }
+
+:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].link-to-learning::inside {
+  class: "os-note-body";
+  content: pending(noteSubtitle) content(); }
+
+:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].link-to-learning:deferred::before {
+  container: span;
+  class: "os-title-label";
+  content: "Link to Learning";
+  move-to: bNoteLabel; }
+
+:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].link-to-learning:deferred::before {
+  container: h3;
+  content: pending(bNoteLabel);
+  class: "os-title";
+  attr-data-type: "title"; }
+
+:pass(2) [data-type="note"] [data-type="note"].link-to-learning > div[data-type="title"]::deferred {
+  container: h5;
+  class: "os-subtitle";
+  move-to: noteSubtitledepth1; }
+
+:pass(2) [data-type="note"] [data-type="note"].link-to-learning > div[data-type="title"]::inside {
+  container: span;
+  class: "os-subtitle-label"; }
+
+:pass(2) [data-type="note"] [data-type="note"].link-to-learning::inside {
+  class: "os-note-body";
+  content: pending(noteSubtitledepth1) content(); }
+
+:pass(2) [data-type="note"] [data-type="note"].link-to-learning:deferred::before {
+  container: span;
+  class: "os-title-label";
+  content: "Link to Learning";
+  move-to: bNoteLabel; }
+
+:pass(2) [data-type="note"] [data-type="note"].link-to-learning:deferred::before {
+  container: h4;
+  content: pending(bNoteLabel);
+  class: "os-title";
+  attr-data-type: "title"; }
+
+:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].real-world > div[data-type="title"]::deferred {
+  container: h4;
+  class: "os-subtitle";
+  move-to: noteSubtitle; }
+
+:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].real-world > div[data-type="title"]::inside {
+  container: span;
+  class: "os-subtitle-label"; }
+
+:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].real-world::inside {
+  class: "os-note-body";
+  content: pending(noteSubtitle) content(); }
+
+:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].real-world:deferred::before {
+  container: span;
+  class: "os-title-label";
+  content: "Cases from the Real World";
+  move-to: bNoteLabel; }
+
+:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].real-world:deferred::before {
+  container: h3;
+  content: pending(bNoteLabel);
+  class: "os-title";
+  attr-data-type: "title"; }
+
+:pass(2) [data-type="note"] [data-type="note"].real-world > div[data-type="title"]::deferred {
+  container: h5;
+  class: "os-subtitle";
+  move-to: noteSubtitledepth1; }
+
+:pass(2) [data-type="note"] [data-type="note"].real-world > div[data-type="title"]::inside {
+  container: span;
+  class: "os-subtitle-label"; }
+
+:pass(2) [data-type="note"] [data-type="note"].real-world::inside {
+  class: "os-note-body";
+  content: pending(noteSubtitledepth1) content(); }
+
+:pass(2) [data-type="note"] [data-type="note"].real-world:deferred::before {
+  container: span;
+  class: "os-title-label";
+  content: "Cases from the Real World";
+  move-to: bNoteLabel; }
+
+:pass(2) [data-type="note"] [data-type="note"].real-world:deferred::before {
+  container: h4;
+  content: pending(bNoteLabel);
+  class: "os-title";
+  attr-data-type: "title"; }
+
+:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].what-would > div[data-type="title"]::deferred {
+  container: h4;
+  class: "os-subtitle";
+  move-to: noteSubtitle; }
+
+:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].what-would > div[data-type="title"]::inside {
+  container: span;
+  class: "os-subtitle-label"; }
+
+:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].what-would::inside {
+  class: "os-note-body";
+  content: pending(noteSubtitle) content(); }
+
+:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].what-would:deferred::before {
+  container: span;
+  class: "os-title-label";
+  content: "What Would You Do?";
+  move-to: bNoteLabel; }
+
+:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].what-would:deferred::before {
+  container: h3;
+  content: pending(bNoteLabel);
+  class: "os-title";
+  attr-data-type: "title"; }
+
+:pass(2) [data-type="note"] [data-type="note"].what-would > div[data-type="title"]::deferred {
+  container: h5;
+  class: "os-subtitle";
+  move-to: noteSubtitledepth1; }
+
+:pass(2) [data-type="note"] [data-type="note"].what-would > div[data-type="title"]::inside {
+  container: span;
+  class: "os-subtitle-label"; }
+
+:pass(2) [data-type="note"] [data-type="note"].what-would::inside {
+  class: "os-note-body";
+  content: pending(noteSubtitledepth1) content(); }
+
+:pass(2) [data-type="note"] [data-type="note"].what-would:deferred::before {
+  container: span;
+  class: "os-title-label";
+  content: "What Would You Do?";
+  move-to: bNoteLabel; }
+
+:pass(2) [data-type="note"] [data-type="note"].what-would:deferred::before {
+  container: h4;
+  content: pending(bNoteLabel);
+  class: "os-title";
+  attr-data-type: "title"; }
+
+:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].ethics-across > div[data-type="title"]::deferred {
+  container: h4;
+  class: "os-subtitle";
+  move-to: noteSubtitle; }
+
+:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].ethics-across > div[data-type="title"]::inside {
+  container: span;
+  class: "os-subtitle-label"; }
+
+:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].ethics-across::inside {
+  class: "os-note-body";
+  content: pending(noteSubtitle) content(); }
+
+:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].ethics-across:deferred::before {
+  container: span;
+  class: "os-title-label";
+  content: "Ethics Across Time and Cultures";
+  move-to: bNoteLabel; }
+
+:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].ethics-across:deferred::before {
+  container: h3;
+  content: pending(bNoteLabel);
+  class: "os-title";
+  attr-data-type: "title"; }
+
+:pass(2) [data-type="note"] [data-type="note"].ethics-across > div[data-type="title"]::deferred {
+  container: h5;
+  class: "os-subtitle";
+  move-to: noteSubtitledepth1; }
+
+:pass(2) [data-type="note"] [data-type="note"].ethics-across > div[data-type="title"]::inside {
+  container: span;
+  class: "os-subtitle-label"; }
+
+:pass(2) [data-type="note"] [data-type="note"].ethics-across::inside {
+  class: "os-note-body";
+  content: pending(noteSubtitledepth1) content(); }
+
+:pass(2) [data-type="note"] [data-type="note"].ethics-across:deferred::before {
+  container: span;
+  class: "os-title-label";
+  content: "Ethics Across Time and Cultures";
+  move-to: bNoteLabel; }
+
+:pass(2) [data-type="note"] [data-type="note"].ethics-across:deferred::before {
+  container: h4;
+  content: pending(bNoteLabel);
+  class: "os-title";
+  attr-data-type: "title"; }
+
+:pass(3) body {
+  counter-reset: chapter; }
+
+:pass(3) div[data-type="chapter"] {
+  counter-increment: chapter; }
+
+:pass(3) div[data-type="chapter"]::before {
+  container: span;
+  content: counter(chapter);
+  class: os-number;
+  move-to: bChapterLabel; }
+
+:pass(3) div[data-type="chapter"]::before {
+  container: span;
+  content: " ";
+  class: os-divider;
+  move-to: bChapterLabel; }
+
+:pass(3) div[data-type="chapter"] > [data-type="document-title"] {
+  container: h1;
+  content: pending(bChapterLabel) content(); }
+
+:pass(3) body {
+  counter-reset: appendix; }
+
+:pass(3) div.appendix {
+  counter-increment: appendix; }
+
+:pass(3) div.appendix::before {
+  container: span;
+  content: counter(appendix, upper-alpha);
+  class: os-number;
+  move-to: bAppendixLabel; }
+
+:pass(3) div.appendix::before {
+  container: span;
+  content: " | ";
+  class: os-divider;
+  move-to: bAppendixLabel; }
+
+:pass(3) div.appendix > [data-type="document-title"] {
+  container: h1;
+  content: pending(bAppendixLabel) content(); }
+
+:pass(3) [data-type="chapter"], :pass(3) .appendix {
+  counter-reset: section; }
+
+:pass(3) div[data-type="chapter"] > div[data-type="page"]:not(.introduction) {
+  counter-increment: section; }
+
+:pass(3) div[data-type="chapter"] > div[data-type="page"]:not(.introduction)::before {
+  container: span;
+  content: counter(chapter) "." counter(section);
+  class: os-number;
+  move-to: bSectionLabel; }
+
+:pass(3) div[data-type="chapter"] > div[data-type="page"]:not(.introduction)::before {
+  container: span;
+  content: " ";
+  class: os-divider;
+  move-to: bSectionLabel; }
+
+:pass(3) div[data-type="chapter"] > div[data-type="page"]:not(.introduction) > [data-type="document-title"] {
+  container: h2;
+  content: pending(bSectionLabel) content(); }
+
+:pass(3) div[data-type="chapter"] > div[data-type="page"].introduction > [data-type="document-title"] {
+  container: h2; }
+
+:pass(3) [data-type="chapter"], :pass(3) .appendix {
+  counter-reset: footnotes; }
+
+:pass(3) [data-type="footnote-ref"] {
+  counter-increment: footnotes; }
+
+:pass(3) [data-type="chapter"], :pass(3) .appendix {
+  counter-reset: footnoteLinks; }
+
+:pass(3) [data-type="footnote-number"] {
+  counter-increment: footnoteLinks; }
+
+:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
+  content: counter(footnotes); }
+
+:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
+  content: counter(footnoteLinks); }
+
+:pass(3) li > a[data-type="footnote-ref"] {
+  content: counter(footnotes); }
+
+:pass(3) a[data-type="footnote-number"] > sup {
+  content: counter(footnoteLinks); }
+
+:pass(3) [data-type="chapter"] {
+  counter-reset: endNotes; }
+
+:pass(3) .references [data-type="note"] {
+  counter-increment: endNotes; }
+
+:pass(3) [data-type="chapter"] {
+  counter-reset: endNotesLinks 1; }
+
+:pass(3) a[data-type="cite"] {
+  counter-increment: endNotesLinks; }
+
+:pass(3) [data-type="cite"] {
+  attr-id: string(pageID) "-endNote" counter(endNotesLinks); }
+  :pass(3) [data-type="cite"]::inside {
+    container: sup;
+    class: 'os-end-note-number';
+    content: target-counter(attr(href), endNotes); }
+
+:pass(3) .references [data-type="note"] a {
+  attr-href: "#" string(pageID) "-endNote" counter(endNotes); }
+  :pass(3) .references [data-type="note"] a span {
+    content: counter(endNotes); }
+
+:pass(3) body {
+  counter-reset: term; }
+
+:pass(3) div[data-type="page"] span[data-type="term"], :pass(3) div[data-type="composite-page"] span[data-type="term"] {
+  counter-increment: term; }
+
+:pass(3) div[data-type="page"],
+:pass(3) div[data-type="composite-page"] {
+  string-set: pageID attr(id); }
+
+:pass(3) div[data-type="page"] span[data-type="term"],
+:pass(3) div[data-type="composite-page"] span[data-type="term"] {
+  attr-id: "auto_" string(pageID) "_term" counter(term); }
+  :pass(3) div[data-type="page"] span[data-type="term"][cmlnle|reference]::after,
+  :pass(3) div[data-type="composite-page"] span[data-type="term"][cmlnle|reference]::after {
+    container: span;
+    data-type: term-content;
+    content: attr(cmlnle|reference); }
+  :pass(3) div[data-type="page"] span[data-type="term"]:not([cmlnle|reference])::after,
+  :pass(3) div[data-type="composite-page"] span[data-type="term"]:not([cmlnle|reference])::after {
+    container: span;
+    data-type: term-content;
+    content: content(); }
+
+:pass(3) div[data-type="page"] > [data-type="document-title"],
+:pass(3) div[data-type="composite-page"] > [data-type="document-title"] {
+  node-set: sectionHeaderNode; }
+
+:pass(3) div[data-type="chapter"] {
+  string-set: chap-id attr(id); }
+  :pass(3) div[data-type="chapter"] section.section-summary {
+    /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
+    content: nodes(sectionHeaderNode) content();
+    move-to: section-summary-TOCOMPOSITE; }
+    :pass(3) div[data-type="chapter"] section.section-summary > [data-type="title"] {
+      /* Discard this Page-specific title because a chapter title is added when collated */
+      move-to: trash; }
+  :pass(3) div[data-type="chapter"]::after {
+    container: div;
+    content: pending(section-summary-TOCOMPOSITE);
+    class: "os-eoc os-section-summary-container";
+    data-type: "composite-page";
+    data-uuid-key: ".section-summary"; }
+
+:pass(3) div[data-type="chapter"] {
+  string-set: chap-id attr(id); }
+  :pass(3) div[data-type="chapter"] div[data-type="glossary"] {
+    /* Discard this Page-specific glossary because it is collated later and the title is added when this is collated */
+    move-to: trash; }
+  :pass(3) div[data-type="chapter"] div[data-type="glossary"] dl {
+    move-to: glossary-TOCOMPOSITE; }
+    :pass(3) div[data-type="chapter"] div[data-type="glossary"] dl > [data-type="title"] {
+      /* Discard this Page-specific title because a chapter title is added when collated */
+      move-to: trash; }
+  :pass(3) div[data-type="chapter"]::after {
+    container: div;
+    content: pending(glossary-TOCOMPOSITE);
+    class: "os-eoc os-glossary-container";
+    data-type: "composite-page";
+    data-uuid-key: "glossary";
+    sort-by: xhtml|dl > xhtml|dt, nocase; }
+
+:pass(3) div[data-type="chapter"] {
+  string-set: chap-id attr(id); }
+  :pass(3) div[data-type="chapter"] section.assessment-questions {
+    move-to: assessment-questions-TOCOMPOSITE; }
+    :pass(3) div[data-type="chapter"] section.assessment-questions > [data-type="title"] {
+      /* Discard this Page-specific title because a chapter title is added when collated */
+      move-to: trash; }
+  :pass(3) div[data-type="chapter"]::after {
+    container: div;
+    content: pending(assessment-questions-TOCOMPOSITE);
+    class: "os-eoc os-assessment-questions-container";
+    data-type: "composite-page";
+    data-uuid-key: ".assessment-questions"; }
+
+:pass(3) div[data-type="chapter"] {
+  string-set: chap-id attr(id); }
+  :pass(3) div[data-type="chapter"] section.references {
+    move-to: references-TOCOMPOSITE; }
+    :pass(3) div[data-type="chapter"] section.references > [data-type="title"] {
+      /* Discard this Page-specific title because a chapter title is added when collated */
+      move-to: trash; }
+  :pass(3) div[data-type="chapter"]::after {
+    container: div;
+    content: pending(references-TOCOMPOSITE);
+    class: "os-eoc os-references-container";
+    data-type: "composite-page";
+    data-uuid-key: ".references"; }
+
+:pass(3) div[data-type="chapter"] {
+  string-set: chap-id attr(id); }
+  :pass(3) div[data-type="chapter"] section.figure-credits {
+    move-to: figure-credits-TOCOMPOSITE; }
+    :pass(3) div[data-type="chapter"] section.figure-credits > [data-type="title"] {
+      /* Discard this Page-specific title because a chapter title is added when collated */
+      move-to: trash; }
+  :pass(3) div[data-type="chapter"]::after {
+    container: div;
+    content: pending(figure-credits-TOCOMPOSITE);
+    class: "os-eoc os-figure-credits-container";
+    data-type: "composite-page";
+    data-uuid-key: ".figure-credits"; }
+
+:pass(3) div[data-type="chapter"] {
+  string-set: chap-id attr(id); }
+  :pass(3) div[data-type="chapter"] section.case-study {
+    move-to: case-study-TOCOMPOSITE; }
+    :pass(3) div[data-type="chapter"] section.case-study > [data-type="title"] {
+      /* Discard this Page-specific title because a chapter title is added when collated */
+      move-to: trash; }
+  :pass(3) div[data-type="chapter"]::after {
+    container: div;
+    content: pending(case-study-TOCOMPOSITE);
+    class: "os-eoc os-case-study-container";
+    data-type: "composite-page";
+    data-uuid-key: ".case-study"; }
+
+:pass(4) [data-type="chapter"] [data-type="page"]:not(.introduction) > [data-type="document-title"] {
+  string-set: outlinePageId attr(id); }
+  :pass(4) [data-type="chapter"] [data-type="page"]:not(.introduction) > [data-type="document-title"]::after {
+    container: a;
+    class: "os-chapter-objective";
+    content: content();
+    attr-href: "#" string(outlinePageId);
+    move-to: chapOutlineLink; }
+
+:pass(4) [data-type="chapter"] [data-type="page"]:not(.introduction)::after {
+  class: "os-chapter-objective";
+  content: pending(chapOutlineLink) pending(outlineLO);
+  move-to: chapOutline; }
+
+:pass(4) [data-type="chapter"]::before {
+  container: h3;
+  class: "os-title";
+  content: "Chapter Outline";
+  move-to: chapOutlineTitle; }
+
+:pass(4) [data-type="chapter"]:deferred::before {
+  class: "os-chapter-outline";
+  content: pending(chapOutlineTitle) pending(chapOutline); }
+
+:pass(4) .introduction [data-type="abstract"] {
+  move-to: trash; }
+
+:pass(5) div[data-type="page"] span[data-type="term"] > span[data-type="term-content"],
+:pass(5) div[data-type="composite-page"] span[data-type="term"] > span[data-type="term-content"] {
+  data-visited: true;
+  move-to: term-trash; }
+  :pass(5) div[data-type="page"] span[data-type="term"] > span[data-type="term-content"]:match(\^\[a-zA-Z\]),
+  :pass(5) div[data-type="composite-page"] span[data-type="term"] > span[data-type="term-content"]:match(\^\[a-zA-Z\]) {
+    string-set: group-by first-letter(content());
+    data-done: true; }
+  :pass(5) div[data-type="page"] span[data-type="term"] > span[data-type="term-content"]:match(\^\[\^a-zA-Z\]),
+  :pass(5) div[data-type="composite-page"] span[data-type="term"] > span[data-type="term-content"]:match(\^\[\^a-zA-Z\]) {
+    string-set: group-by " Symbols";
+    data-done: true; }
+
+:pass(5) div[data-type="page"] span[data-type="term"]:deferred,
+:pass(5) div[data-type="composite-page"] span[data-type="term"]:deferred {
+  attr-group-by: string(group-by); }
+
+:pass(5) body:deferred::after {
+  content: clear(term-trash); }
+
+:pass(6) div[data-type="page"] > [data-type="document-title"],
+:pass(6) div[data-type="composite-page"] > [data-type="document-title"] {
+  node-set: sectionHeaderNode; }
+
+:pass(6) div[data-type="page"] > [data-type="document-title"],
+:pass(6) div[data-type="composite-page"] > [data-type="document-title"] {
+  string-set: sectionHeaderString content(); }
+
+:pass(6) div[data-type="page"] span[data-type="term"]::after, :pass(6) div[data-type="composite-page"] span[data-type="term"]::after {
+  content: attr(cmlnle|reference, content());
+  attr-group-by: attr(group-by);
+  container: span;
+  class: "os-term";
+  move-to: index-term; }
+
+:pass(6) div[data-type="page"] span[data-type="term"]::after, :pass(6) div[data-type="composite-page"] span[data-type="term"]::after {
+  content: string(sectionHeaderString);
+  container: span;
+  class: "os-term-section";
+  move-to: index-section; }
+
+:pass(6) div[data-type="page"] span[data-type="term"]::after, :pass(6) div[data-type="composite-page"] span[data-type="term"]::after {
+  container: a;
+  content: pending(index-section);
+  attr-href: "#" attr(id);
+  class: "os-term-section-link";
+  move-to: index-section-link; }
+
+:pass(6) div[data-type="page"] span[data-type="term"]::after, :pass(6) div[data-type="composite-page"] span[data-type="term"]::after {
+  container: span;
+  content: ', ';
+  class: "os-index-link-separator";
+  move-to: index-section-link; }
+
+:pass(6) div[data-type="page"] span[data-type="term"]::after, :pass(6) div[data-type="composite-page"] span[data-type="term"]::after {
+  content: pending(index-term) pending(index-section-link);
+  class: os-index-item;
+  move-to: index-TOCOMPOSITE; }
+
+:pass(6) .os-chapter-outline {
+  move-to: ChapterOutline; }
+
+:pass(6) .introduction {
+  content: pending(ChapterOutline) content(); }
+
+:pass(6) [data-type="chapter"], :pass(6) .appendix {
+  counter-reset: exercise; }
+
+:pass(6) .os-eoc [data-type="exercise"] {
+  counter-increment: exercise; }
+
+:pass(6) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
+  container: span;
+  content: ". ";
+  class: os-divider; }
+
+:pass(6) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
+  container: span;
+  content: counter(exercise);
+  class: os-number; }
+
+:pass(6) .os-eoc [data-type="exercise"] [data-type="solution"]::before {
+  container: span;
+  content: ". ";
+  class: os-divider; }
+
+:pass(6) .os-eoc [data-type="exercise"] [data-type="solution"]::before {
+  container: span;
+  content: counter(exercise);
+  class: os-number; }
+
+:pass(7) body {
+  counter-reset: exerciseAll; }
+
+:pass(7) .os-eoc [data-type="exercise"] {
+  counter-increment: exerciseAll; }
+
+:pass(7) [data-type="exercise"].os-hasSolution {
+  string-set: exerciseId attr(id); }
+  :pass(7) [data-type="exercise"].os-hasSolution [data-type="problem"] > .os-number {
+    container: a;
+    attr-href: "#" string(exerciseId) "-solution"; }
+  :pass(7) [data-type="exercise"].os-hasSolution [data-type="solution"] {
+    attr-id: string(exerciseId) "-solution"; }
+    :pass(7) [data-type="exercise"].os-hasSolution [data-type="solution"] > .os-number {
+      container: a;
+      attr-href: "#" string(exerciseId); }
+
+:pass(8) div[data-type="page"] > [data-type="document-title"],
+:pass(8) div[data-type="composite-page"] > [data-type="document-title"] {
+  node-set: sectionHeaderNode; }
+
+:pass(8) [data-type="chapter"] .os-eoc.os-assessment-questions-container [data-type="solution"] {
+  move-to: solution-GETCHAPTER; }
+
+:pass(8) [data-type="chapter"] > h1[data-type="document-title"] .os-number {
+  string-set: ChapNum content(); }
+
+:pass(8) [data-type="chapter"]::after {
+  container: span;
+  class: "os-text";
+  content: "Chapter " string(ChapNum);
+  move-to: eobCompositeTitlesContent; }
+
+:pass(8) [data-type="chapter"]::after {
+  content: pending(eobCompositeTitlesContent) pending(note-solution-GETCHAPTER) pending(solution-GETCHAPTER);
+  class: "os-eob os-solution-container";
+  data-type: "composite-page";
+  data-uuid-key: ".solution" string(ChapNum);
+  move-to: solution-TOCOMPOSITECHAPTER; }
+
+:pass(8) body::after {
+  content: pending(solution-TOCOMPOSITECHAPTER);
+  class: "os-eob os-solution-container";
+  data-type: "composite-chapter";
+  data-uuid-key: ".solution";
+  /* TODO: Is this the correct key? We'll be stuck with it because it is used for generating the collated page uuid's */ }
+
+:pass(8) body::after {
+  container: div;
+  content: pending(solution-TOCOMPOSITE);
+  class: "os-eob os-solution-container";
+  data-type: "composite-page";
+  data-uuid-key: ".solution"; }
+
+:pass(8) body::after {
+  container: div;
+  content: pending(index-TOCOMPOSITE);
+  class: "os-eob os-index-container";
+  data-type: "composite-page";
+  data-uuid-key: "index";
+  group-by: span, "span::attr(group-by)", nocase; }
+
+:pass(9) .os-index-container > div.group-by:first-of-type > span.group-label:match(\^\[ \]\(Symbols\|SYMBOLS\)) {
+  content: "Symbols"; }
+
+:pass(9) body {
+  counter-reset: chapter; }
+
+:pass(9) div[data-type="chapter"] {
+  counter-increment: chapter; }
+
+:pass(9) body {
+  counter-reset: appendix; }
+
+:pass(9) div.appendix {
+  counter-increment: appendix; }
+
+:pass(9) [data-type="chapter"], :pass(9) .appendix {
+  counter-reset: section; }
+
+:pass(9) div[data-type="chapter"] > div[data-type="page"]:not(.introduction) {
+  counter-increment: section; }
+
+:pass(9) [data-type="chapter"], :pass(9) .appendix {
+  counter-reset: exercise; }
+
+:pass(9) .os-eoc [data-type="exercise"] {
+  counter-increment: exercise; }
+
+:pass(9) [data-type="chapter"], :pass(9) .appendix {
+  counter-reset: example; }
+
+:pass(9) div[data-type="chapter"] [data-type="example"], :pass(9) .appendix [data-type="example"] {
+  counter-increment: example; }
+
+:pass(9) [data-type="chapter"], :pass(9) .appendix {
+  counter-reset: equation; }
+
+:pass(9) [data-type="equation"]:not(.unnumbered) {
+  counter-increment: equation; }
+
+:pass(9) .os-eoc [data-type="exercise"] {
+  string-set: target-label "Exercise " counter(chapter) "." counter(exercise);
+  string-set: target-label-nominative "Exercise " counter(chapter) "." counter(exercise); }
+
+:pass(9) div[data-type="chapter"] [data-type="example"] {
+  string-set: target-label "Example " counter(chapter) "." counter(example);
+  string-set: target-label-nominative "Example " counter(chapter) "." counter(example); }
+
+:pass(9) div[data-type="chapter"] [data-type="equation"]:not(.unnumbered) {
+  string-set: target-label "Equation " counter(chapter) "." counter(equation);
+  string-set: target-label-nominative "Equation " counter(chapter) "." counter(equation); }
+
+:pass(9) [data-type="chapter"] :not(table) > table:not(.unnumbered) {
+  string-set: target-label "Table " counter(chapter) "." counter(table);
+  string-set: target-label-nominative "Table " counter(chapter) "." counter(table); }
+
+:pass(9) [data-type="chapter"] :not(figure) > figure:not(.unnumbered) {
+  string-set: target-label "Figure " counter(chapter) "." counter(figure);
+  string-set: target-label-nominative "Figure " counter(chapter) "." counter(figure); }
+
+:pass(9) .appendix :not(table) > table:not(.unnumbered) {
+  string-set: target-label "Table " counter(appendix, upper-alpha) counter(table);
+  string-set: target-label-nominative "Table " counter(appendix, upper-alpha) counter(table); }
+
+:pass(9) .appendix :not(figure) > figure:not(.unnumbered) {
+  string-set: target-label "Figure " counter(appendix, upper-alpha) counter(figure);
+  string-set: target-label-nominative "Figure " counter(appendix, upper-alpha) counter(figure); }
+
+:pass(9) .appendix > table:not(.unnumbered) {
+  string-set: target-label "Table " counter(appendix, upper-alpha) counter(table);
+  string-set: target-label-nominative "Table " counter(appendix, upper-alpha) counter(table); }
+
+:pass(9) .appendix > figure:not(.unnumbered) {
+  string-set: target-label "Figure " counter(appendix, upper-alpha) counter(figure);
+  string-set: target-label-nominative "Figure " counter(appendix, upper-alpha) counter(figure); }
+
+:pass(9) .preface :not(table) > table:not(.unnumbered) {
+  string-set: target-label "Table " counter(table);
+  string-set: target-label-nominative "Table " counter(table); }
+
+:pass(9) .preface :not(figure) > figure:not(.unnumbered) {
+  string-set: target-label "Figure " counter(figure);
+  string-set: target-label-nominative "Figure " counter(figure); }
+
+:pass(9) .appendix [data-type="example"] {
+  string-set: target-label "Example " counter(appendix, upper-alpha) counter(example);
+  string-set: target-label-nominative "Example " counter(appendix, upper-alpha) counter(example); }
+
+:pass(9) a.autogenerated-content {
+  content: target-string(attr(href), target-label); }
+  :pass(9) a.autogenerated-content[cmlnle|case="nominative"] {
+    content: target-string(attr(href), target-label-nominative); }
+
+:pass(9) body > [data-type="metadata"] {
+  node-set: bookMetadata; }
+
+:pass(9) [data-type="composite-page"], :pass(9) [data-type="composite-chapter"] {
+  content: nodes(bookMetadata) content(); }
+
+:pass(9) [data-type="composite-page"].os-eoc.os-section-summary-container::before {
+  container: span;
+  content: "Summary";
+  class: os-text;
+  move-to: h2-TITLECONTAINER; }
+
+:pass(9) [data-type="composite-page"].os-eoc.os-section-summary-container::before {
+  container: h2;
+  data-type: "document-title";
+  content: pending(h2-TITLECONTAINER); }
+
+:pass(9) [data-type="composite-page"].os-eoc.os-glossary-container::before {
+  container: span;
+  content: "Key Terms";
+  class: os-text;
+  move-to: h2-TITLECONTAINER; }
+
+:pass(9) [data-type="composite-page"].os-eoc.os-glossary-container::before {
+  container: h2;
+  data-type: "document-title";
+  content: pending(h2-TITLECONTAINER); }
+
+:pass(9) [data-type="composite-page"].os-eoc.os-assessment-questions-container::before {
+  container: span;
+  content: "Assessment Questions";
+  class: os-text;
+  move-to: h2-TITLECONTAINER; }
+
+:pass(9) [data-type="composite-page"].os-eoc.os-assessment-questions-container::before {
+  container: h2;
+  data-type: "document-title";
+  content: pending(h2-TITLECONTAINER); }
+
+:pass(9) [data-type="composite-page"].os-eoc.os-references-container::before {
+  container: span;
+  content: "End Notes";
+  class: os-text;
+  move-to: h2-TITLECONTAINER; }
+
+:pass(9) [data-type="composite-page"].os-eoc.os-references-container::before {
+  container: h2;
+  data-type: "document-title";
+  content: pending(h2-TITLECONTAINER); }
+
+:pass(9) [data-type="composite-page"].os-eoc.os-figure-credits-container::before {
+  container: span;
+  content: "Figure Credits";
+  class: os-text;
+  move-to: h2-TITLECONTAINER; }
+
+:pass(9) [data-type="composite-page"].os-eoc.os-figure-credits-container::before {
+  container: h2;
+  data-type: "document-title";
+  content: pending(h2-TITLECONTAINER); }
+
+:pass(9) [data-type="composite-page"].os-eoc.os-case-study-container::before {
+  container: span;
+  content: "Case Study";
+  class: os-text;
+  move-to: h2-TITLECONTAINER; }
+
+:pass(9) [data-type="composite-page"].os-eoc.os-case-study-container::before {
+  container: h2;
+  data-type: "document-title";
+  content: pending(h2-TITLECONTAINER); }
+
+:pass(9) [data-type="composite-chapter"].os-eob.os-solution-container::before {
+  container: span;
+  content: "Answer Key";
+  class: os-text;
+  move-to: h1-TITLECONTAINER; }
+
+:pass(9) [data-type="composite-chapter"].os-eob.os-solution-container::before {
+  container: h1;
+  data-type: "document-title";
+  content: pending(h1-TITLECONTAINER); }
+
+:pass(9) [data-type="composite-chapter"].os-eob.os-solution-container [data-type="composite-page"] > span.os-text {
+  move-to: CCcompositePageTitles; }
+
+:pass(9) [data-type="composite-chapter"].os-eob.os-solution-container [data-type="composite-page"]:deferred::before {
+  container: h2;
+  data-type: document-title;
+  content: pending(CCcompositePageTitles); }
+
+:pass(9) [data-type="composite-page"].os-eob.os-index-container::before {
+  container: span;
+  content: "Index";
+  class: os-text;
+  move-to: h1-TITLECONTAINER; }
+
+:pass(9) [data-type="composite-page"].os-eob.os-index-container::before {
+  container: h1;
+  data-type: "document-title";
+  content: pending(h1-TITLECONTAINER); }
+
+:pass(9) div[data-type='chapter'] > h1[data-type='document-title'] {
+  counter-increment: chapTitleNum;
+  attr-id: "chapTitle" counter(chapTitleNum); }
+
+:pass(9) [data-type="chapter"], :pass(9) .appendix {
+  counter-reset: exerciseMaybeInContent; }
+
+:pass(9) :not([data-type="example"]) > [data-type="exercise"]:not(.unnumbered) {
+  counter-increment: exerciseMaybeInContent; }
+
+:pass(9) [data-type="chapter"] [data-type="page"] [data-type="exercise"]:not(.unnumbered):not(.os-hasStimulus) [data-type="problem"]::before {
+  container: span;
+  content: counter(exerciseMaybeInContent);
+  class: os-number; }
+
+:pass(9) [data-type="chapter"] [data-type="page"] [data-type="exercise"]:not(.unnumbered):not(.os-hasStimulus) [data-type="problem"]::before {
+  container: span;
+  content: "Exercise ";
+  class: os-title-label; }
+
+:pass(9) .appendix [data-type="exercise"]:not(.unnumbered) [data-type="problem"]::before {
+  container: span;
+  content: counter(exerciseMaybeInContent);
+  class: os-number; }
+
+:pass(9) .appendix [data-type="exercise"]:not(.unnumbered) [data-type="problem"]::before {
+  container: span;
+  content: "Exercise ";
+  class: os-title-label; }
+
+:pass(9) [data-type="chapter"], :pass(9) .appendix, :pass(9) .preface {
+  counter-reset: table; }
+
+:pass(9) :not(table) > table:not(.unnumbered) {
+  counter-increment: table; }
+
+:pass(9) [data-type="chapter"], :pass(9) .appendix, :pass(9) .preface {
+  counter-reset: figure; }
+
+:pass(9) :not(figure) > figure:not(.unnumbered) {
+  counter-increment: figure; }
+
+:pass(9) [data-type="chapter"] :not(table) > table:not(.unnumbered)::before {
+  container: span;
+  content: "Table ";
+  class: os-title-label;
+  move-to: bCaption; }
+
+:pass(9) [data-type="chapter"] :not(table) > table:not(.unnumbered)::before {
+  container: span;
+  content: counter(chapter) "." counter(table);
+  class: os-number;
+  move-to: bCaption; }
+
+:pass(9) [data-type="chapter"] :not(table) > table:not(.unnumbered)::before {
+  container: span;
+  content: " ";
+  class: os-divider;
+  move-to: bCaption; }
+
+:pass(9) [data-type="chapter"] :not(table) > table:not(.unnumbered).top-titled thead tr:first-child {
+  string-set: TopTitleContent content();
+  move-to: trash; }
+
+:pass(9) [data-type="chapter"] :not(table) > table:not(.unnumbered) caption {
+  container: span;
+  class: "os-caption";
+  move-to: bCaptionContent; }
+
+:pass(9) [data-type="chapter"] :not(table) > table:not(.unnumbered)::after {
+  container: span;
+  class: 'os-divider';
+  content: ' ';
+  move-to: bCaptionDivider; }
+
+:pass(9) [data-type="chapter"] :not(table) > table:not(.unnumbered) caption [data-type="title"] {
+  container: span;
+  class: "os-title";
+  move-to: bCaptionTitle; }
+
+:pass(9) [data-type="chapter"] :not(table) > table:not(.unnumbered)::after {
+  container: div;
+  class: "os-caption-container";
+  content: pending(bCaption) pending(bCaptionTitle) pending(bCaptionDivider) pending(bCaptionContent);
+  move-to: bCaptionContainer; }
+
+:pass(9) [data-type="chapter"] :not(table) > table:not(.unnumbered).top-titled::after {
+  class: "os-table-title";
+  content: string(TopTitleContent);
+  move-to: tableTopTitle; }
+
+:pass(9) [data-type="chapter"] :not(table) > table:not(.unnumbered)::outside {
+  class: os-table;
+  container: div;
+  content: pending(tableTopTitle) content() pending(bCaptionContainer); }
+
+:pass(9) [data-type="chapter"] > table.unnumbered caption {
+  move-to: trash; }
+
+:pass(9) .appendix :not(table) > table:not(.unnumbered)::before,
+:pass(9) .appendix > table:not(.unnumbered)::before {
+  container: span;
+  content: "Table ";
+  class: os-title-label;
+  move-to: bCaption; }
+
+:pass(9) .appendix :not(table) > table:not(.unnumbered)::before,
+:pass(9) .appendix > table:not(.unnumbered)::before {
+  container: span;
+  content: counter(appendix, upper-alpha) counter(table);
+  class: os-number;
+  move-to: bCaption; }
+
+:pass(9) .appendix :not(table) > table:not(.unnumbered)::before,
+:pass(9) .appendix > table:not(.unnumbered)::before {
+  container: span;
+  content: " ";
+  class: os-divider;
+  move-to: bCaption; }
+
+:pass(9) .appendix :not(table) > table:not(.unnumbered) caption,
+:pass(9) .appendix > table:not(.unnumbered) caption {
+  container: span;
+  class: "os-caption";
+  move-to: bCaptionContent; }
+
+:pass(9) .appendix :not(table) > table:not(.unnumbered)::after,
+:pass(9) .appendix > table:not(.unnumbered)::after {
+  container: span;
+  class: 'os-divider';
+  content: ' ';
+  move-to: bCaptionDivider; }
+
+:pass(9) .appendix :not(table) > table:not(.unnumbered) caption [data-type="title"],
+:pass(9) .appendix > table:not(.unnumbered) caption [data-type="title"] {
+  container: span;
+  class: "os-title";
+  move-to: bCaptionTitle; }
+
+:pass(9) .appendix :not(table) > table:not(.unnumbered)::after,
+:pass(9) .appendix > table:not(.unnumbered)::after {
+  container: div;
+  class: "os-caption-container";
+  content: pending(bCaption) pending(bCaptionTitle) pending(bCaptionDivider) pending(bCaptionContent);
+  move-to: bCaptionContainer; }
+
+:pass(9) .appendix :not(table) > table:not(.unnumbered).top-titled::after,
+:pass(9) .appendix > table:not(.unnumbered).top-titled::after {
+  class: "os-table-title";
+  content: string(TopTitleContent);
+  move-to: tableTopTitle; }
+
+:pass(9) .appendix :not(table) > table:not(.unnumbered)::outside,
+:pass(9) .appendix > table:not(.unnumbered)::outside {
+  class: os-table;
+  container: div;
+  content: pending(tableTopTitle) content() pending(bCaptionContainer); }
+
+:pass(9) .appendix > table.unnumbered caption {
+  move-to: trash; }
+
+:pass(9) .preface :not(table) > table:not(.unnumbered)::before {
+  container: span;
+  content: "Table ";
+  class: os-title-label;
+  move-to: bCaption; }
+
+:pass(9) .preface :not(table) > table:not(.unnumbered)::before {
+  container: span;
+  content: counter(table);
+  class: os-number;
+  move-to: bCaption; }
+
+:pass(9) .preface :not(table) > table:not(.unnumbered)::before {
+  container: span;
+  content: " ";
+  class: os-divider;
+  move-to: bCaption; }
+
+:pass(9) .preface :not(table) > table:not(.unnumbered) caption {
+  container: span;
+  class: "os-caption";
+  move-to: bCaptionContent; }
+
+:pass(9) .preface :not(table) > table:not(.unnumbered)::after {
+  container: span;
+  class: 'os-divider';
+  content: ' ';
+  move-to: bCaptionDivider; }
+
+:pass(9) .preface :not(table) > table:not(.unnumbered) caption [data-type="title"] {
+  container: span;
+  class: "os-title";
+  move-to: bCaptionTitle; }
+
+:pass(9) .preface :not(table) > table:not(.unnumbered)::after {
+  container: div;
+  class: "os-caption-container";
+  content: pending(bCaption) pending(bCaptionTitle) pending(bCaptionDivider) pending(bCaptionContent);
+  move-to: bCaptionContainer; }
+
+:pass(9) .preface :not(table) > table:not(.unnumbered).top-titled::after {
+  class: "os-table-title";
+  content: string(TopTitleContent);
+  move-to: tableTopTitle; }
+
+:pass(9) .preface :not(table) > table:not(.unnumbered)::outside {
+  class: os-table;
+  container: div;
+  content: pending(tableTopTitle) content() pending(bCaptionContainer); }
+
+:pass(9) .preface > table.unnumbered caption {
+  move-to: trash; }
+
+:pass(9) [data-type="chapter"] :not(figure) > figure:not(.unnumbered)::before {
+  container: span;
+  content: "Figure ";
+  class: os-title-label;
+  move-to: bCaption; }
+
+:pass(9) [data-type="chapter"] :not(figure) > figure:not(.unnumbered)::before {
+  container: span;
+  content: counter(chapter) "." counter(figure);
+  class: os-number;
+  move-to: bCaption; }
+
+:pass(9) [data-type="chapter"] :not(figure) > figure:not(.unnumbered)::before {
+  container: span;
+  content: " ";
+  class: os-divider;
+  move-to: bCaption; }
+
+:pass(9) [data-type="chapter"] :not(figure) > figure:not(.unnumbered) figcaption {
+  container: span;
+  class: "os-caption";
+  move-to: bCaptionContent; }
+
+:pass(9) [data-type="chapter"] :not(figure) > figure:not(.unnumbered)::after {
+  container: span;
+  class: 'os-divider';
+  content: ' ';
+  move-to: bCaptionDivider; }
+
+:pass(9) [data-type="chapter"] :not(figure) > figure:not(.unnumbered) [data-type="title"] {
+  container: span;
+  class: "os-title";
+  move-to: bCaptionTitle; }
+
+:pass(9) [data-type="chapter"] :not(figure) > figure:not(.unnumbered)::after {
+  container: div;
+  class: "os-caption-container";
+  content: pending(bCaption) pending(bCaptionTitle) pending(bCaptionDivider) pending(bCaptionContent);
+  move-to: bCaptionContainer; }
+
+:pass(9) [data-type="chapter"] :not(figure) > figure:not(.unnumbered)::outside {
+  class: os-figure;
+  container: div;
+  content: content() pending(bCaptionContainer); }
+
+:pass(9) [data-type="chapter"] > figure.unnumbered figcaption {
+  move-to: trash; }
+
+:pass(9) .appendix :not(figure) > figure:not(.unnumbered)::before,
+:pass(9) .appendix > figure:not(.unnumbered)::before {
+  container: span;
+  content: "Figure ";
+  class: os-title-label;
+  move-to: bCaption; }
+
+:pass(9) .appendix :not(figure) > figure:not(.unnumbered)::before,
+:pass(9) .appendix > figure:not(.unnumbered)::before {
+  container: span;
+  content: counter(appendix, upper-alpha) counter(figure);
+  class: os-number;
+  move-to: bCaption; }
+
+:pass(9) .appendix :not(figure) > figure:not(.unnumbered)::before,
+:pass(9) .appendix > figure:not(.unnumbered)::before {
+  container: span;
+  content: " ";
+  class: os-divider;
+  move-to: bCaption; }
+
+:pass(9) .appendix :not(figure) > figure:not(.unnumbered) figcaption,
+:pass(9) .appendix > figure:not(.unnumbered) figcaption {
+  container: span;
+  class: "os-caption";
+  move-to: bCaptionContent; }
+
+:pass(9) .appendix :not(figure) > figure:not(.unnumbered)::after,
+:pass(9) .appendix > figure:not(.unnumbered)::after {
+  container: span;
+  class: 'os-divider';
+  content: ' ';
+  move-to: bCaptionDivider; }
+
+:pass(9) .appendix :not(figure) > figure:not(.unnumbered) [data-type="title"],
+:pass(9) .appendix > figure:not(.unnumbered) [data-type="title"] {
+  container: span;
+  class: "os-title";
+  move-to: bCaptionTitle; }
+
+:pass(9) .appendix :not(figure) > figure:not(.unnumbered)::after,
+:pass(9) .appendix > figure:not(.unnumbered)::after {
+  container: div;
+  class: "os-caption-container";
+  content: pending(bCaption) pending(bCaptionTitle) pending(bCaptionDivider) pending(bCaptionContent);
+  move-to: bCaptionContainer; }
+
+:pass(9) .appendix :not(figure) > figure:not(.unnumbered)::outside,
+:pass(9) .appendix > figure:not(.unnumbered)::outside {
+  class: os-figure;
+  container: div;
+  content: content() pending(bCaptionContainer); }
+
+:pass(9) .appendix > figure.unnumbered figcaption {
+  move-to: trash; }
+
+:pass(9) .preface :not(figure) > figure:not(.unnumbered)::before {
+  container: span;
+  content: "Figure ";
+  class: os-title-label;
+  move-to: bCaption; }
+
+:pass(9) .preface :not(figure) > figure:not(.unnumbered)::before {
+  container: span;
+  content: counter(figure);
+  class: os-number;
+  move-to: bCaption; }
+
+:pass(9) .preface :not(figure) > figure:not(.unnumbered)::before {
+  container: span;
+  content: " ";
+  class: os-divider;
+  move-to: bCaption; }
+
+:pass(9) .preface :not(figure) > figure:not(.unnumbered) figcaption {
+  container: span;
+  class: "os-caption";
+  move-to: bCaptionContent; }
+
+:pass(9) .preface :not(figure) > figure:not(.unnumbered)::after {
+  container: span;
+  class: 'os-divider';
+  content: ' ';
+  move-to: bCaptionDivider; }
+
+:pass(9) .preface :not(figure) > figure:not(.unnumbered) [data-type="title"] {
+  container: span;
+  class: "os-title";
+  move-to: bCaptionTitle; }
+
+:pass(9) .preface :not(figure) > figure:not(.unnumbered)::after {
+  container: div;
+  class: "os-caption-container";
+  content: pending(bCaption) pending(bCaptionTitle) pending(bCaptionDivider) pending(bCaptionContent);
+  move-to: bCaptionContainer; }
+
+:pass(9) .preface :not(figure) > figure:not(.unnumbered)::outside {
+  class: os-figure;
+  container: div;
+  content: content() pending(bCaptionContainer); }
+
+:pass(9) .preface > figure.unnumbered figcaption {
+  move-to: trash; }
+
+:pass(9) .preface [data-type="abstract"] {
+  move-to: trash; }
+
+:pass(9) [data-type="chapter"] [data-type="page"] :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"] > .os-title,
+:pass(9) [data-type="chapter"] [data-type="page"] [data-type="example"] > .os-title,
+:pass(9) [data-type="chapter"] [data-type="page"] [data-type="exercise"] > .os-title {
+  container: h3; }
+
+:pass(9) [data-type="chapter"] [data-type="page"] :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"] [data-type="solution"] .solution-title,
+:pass(9) [data-type="chapter"] [data-type="page"] [data-type="example"] [data-type="solution"] .solution-title,
+:pass(9) [data-type="chapter"] [data-type="page"] [data-type="exercise"] [data-type="solution"] .solution-title {
+  container: h4; }
+
+:pass(9) [data-type="composite-page"].os-eoc > section > [data-type="document-title"] {
+  container: h3; }
+
+:pass(9) [data-type="composite-page"].os-eoc > div > div > div > section > [data-type="document-title"] {
+  container: h4; }
+
+:pass(9) [data-type="composite-page"].os-eob > .os-chapter-area > [data-type="document-title"] {
+  container: h2; }
+
+:pass(9) [data-type="composite-page"].os-eob > .os-chapter-area > section > [data-type="document-title"] {
+  container: h3; }
+
+:pass(9) [data-type="composite-chapter"] > section [data-type="document-title"], :pass(9) [data-type="composite-chapter"] > section [data-type="title"],
+:pass(9) [data-type="composite-chapter"] > [data-type="page"] [data-type="document-title"],
+:pass(9) [data-type="composite-chapter"] > [data-type="page"] [data-type="title"], :pass(9) [data-type="composite-chapter"] > [data-type="composite-page"] [data-type="document-title"], :pass(9) [data-type="composite-chapter"] > [data-type="composite-page"] [data-type="title"], :pass(9) [data-type="composite-chapter"] [data-type="composite-chapter"] [data-type="document-title"], :pass(9) [data-type="composite-chapter"] [data-type="composite-chapter"] [data-type="title"] {
+  container: h2; }
+
+:pass(9) [data-type="composite-chapter"] > section > section [data-type="document-title"], :pass(9) [data-type="composite-chapter"] > section > section [data-type="title"],
+:pass(9) [data-type="composite-chapter"] > [data-type="page"] > section [data-type="document-title"],
+:pass(9) [data-type="composite-chapter"] > [data-type="page"] > section [data-type="title"], :pass(9) [data-type="composite-chapter"] > [data-type="composite-page"] > section [data-type="document-title"], :pass(9) [data-type="composite-chapter"] > [data-type="composite-page"] > section [data-type="title"], :pass(9) [data-type="composite-chapter"] [data-type="composite-chapter"] > section [data-type="document-title"], :pass(9) [data-type="composite-chapter"] [data-type="composite-chapter"] > section [data-type="title"] {
+  container: h3;
+  data-type: title; }
+
+:pass(9) [data-type="composite-chapter"] > section > section > section [data-type="document-title"], :pass(9) [data-type="composite-chapter"] > section > section > section [data-type="title"],
+:pass(9) [data-type="composite-chapter"] > [data-type="page"] > section > section [data-type="document-title"],
+:pass(9) [data-type="composite-chapter"] > [data-type="page"] > section > section [data-type="title"], :pass(9) [data-type="composite-chapter"] > [data-type="composite-page"] > section > section [data-type="document-title"], :pass(9) [data-type="composite-chapter"] > [data-type="composite-page"] > section > section [data-type="title"], :pass(9) [data-type="composite-chapter"] [data-type="composite-chapter"] > section > section [data-type="document-title"], :pass(9) [data-type="composite-chapter"] [data-type="composite-chapter"] > section > section [data-type="title"] {
+  container: h4; }
+
+:pass(9) [data-type="composite-chapter"] > section [data-type="document-title"], :pass(9) [data-type="composite-chapter"] > section [data-type="title"],
+:pass(9) [data-type="composite-chapter"] > [data-type="composite-page"] [data-type="document-title"],
+:pass(9) [data-type="composite-chapter"] > [data-type="composite-page"] [data-type="title"] {
+  container: h3; }
+
+:pass(9) [data-type="composite-chapter"] > section > section [data-type="document-title"], :pass(9) [data-type="composite-chapter"] > section > section [data-type="title"],
+:pass(9) [data-type="composite-chapter"] > [data-type="composite-page"] > section [data-type="document-title"],
+:pass(9) [data-type="composite-chapter"] > [data-type="composite-page"] > section [data-type="title"] {
+  container: h4;
+  data-type: title; }
+
+:pass(9) [data-type="composite-chapter"] > section > section > section [data-type="document-title"], :pass(9) [data-type="composite-chapter"] > section > section > section [data-type="title"],
+:pass(9) [data-type="composite-chapter"] > [data-type="composite-page"] > section > section [data-type="document-title"],
+:pass(9) [data-type="composite-chapter"] > [data-type="composite-page"] > section > section [data-type="title"] {
+  container: h5; }
+
+:pass(9) .appendix > section > [data-type="title"], :pass(9) .appendix > section [data-type="document-title"] {
+  container: h2; }
+
+:pass(9) .appendix > section > section > [data-type="title"], :pass(9) .appendix > section > section [data-type="document-title"] {
+  container: h3; }
+
+:pass(10) .os-index-link-separator:last-child {
+  move-to: trash; }
+
+:pass(10) [data-type="composite-page"] > [data-type="composite-chapter"] > [data-type="composite-page"] > [data-type="title"], :pass(10) [data-type="composite-chapter"] > [data-type="composite-chapter"] > [data-type="composite-page"] > [data-type="title"] {
+  string-set: Cdoc-title-TOMETADATA content(); }
+
+:pass(10) [data-type="composite-page"] > [data-type="composite-chapter"] > [data-type="composite-page"] > [data-type="metadata"] > [data-type="document-title"], :pass(10) [data-type="composite-chapter"] > [data-type="composite-chapter"] > [data-type="composite-page"] > [data-type="metadata"] > [data-type="document-title"] {
+  content: string(Cdoc-title-TOMETADATA); }
+
+:pass(10) [data-type="composite-page"] > [data-type="document-title"], :pass(10) [data-type="composite-chapter"] > [data-type="document-title"] {
+  string-set: doc-title-TOMETADATA content(); }
+
+:pass(10) [data-type="composite-page"] > [data-type="metadata"] > [data-type="document-title"], :pass(10) [data-type="composite-chapter"] > [data-type="metadata"] > [data-type="document-title"] {
+  content: string(doc-title-TOMETADATA); }
+
+:pass(10) div.os-table:deferred::before {
+  class: 'temp-summary';
+  content: string(tableSummary); }
+
+:pass(10) div.os-table .os-caption-container {
+  string-set: tableSummary content(); }
+
+:pass(10) table > caption:empty {
+  move-to: trash; }
+
+:pass(10) :not(.os-table) > table::outside {
+  container: div;
+  class: os-table; }
+
+:pass(11) div.os-eoc [data-type="cnx-archive-uri"],
+:pass(11) div.os-eob [data-type="cnx-archive-uri"] {
+  move-to: trash; }
+
+:pass(11) [data-type="composite-chapter"] > [data-type="metadata"] > [data-type="cnx-archive-uri"] {
+  move-to: trash; }
+
+:pass(11) body > div[data-type="page"],
+:pass(11) body > div[data-type="composite-page"] {
+  string-set: page-id attr(id); }
+  :pass(11) body > div[data-type="page"] > [data-type='document-title'],
+  :pass(11) body > div[data-type="composite-page"] > [data-type='document-title'] {
+    node-set: pageTitle; }
+  :pass(11) body > div[data-type="page"] > [data-type='metadata']
+> [data-type='cnx-archive-shortid'],
+  :pass(11) body > div[data-type="composite-page"] > [data-type='metadata']
+> [data-type='cnx-archive-shortid'] {
+    string-set: page-shortid attr(data-value); }
+  :pass(11) body > div[data-type="page"]::after,
+  :pass(11) body > div[data-type="composite-page"]::after {
+    content: nodes(pageTitle);
+    attr-href: "#" string(page-id);
+    container: a;
+    move-to: page-link; }
+  :pass(11) body > div[data-type="page"]:not(.appendix)::after,
+  :pass(11) body > div[data-type="composite-page"]:not(.appendix)::after {
+    content: pending(page-link);
+    move-to: eob-toc;
+    attr-cnx-archive-uri: attr(id);
+    attr-cnx-archive-shortid: string(page-shortid);
+    container: li; }
+  :pass(11) body > div[data-type="page"].appendix::after,
+  :pass(11) body > div[data-type="composite-page"].appendix::after {
+    content: pending(page-link);
+    move-to: eob-toc;
+    attr-cnx-archive-uri: attr(id);
+    attr-cnx-archive-shortid: string(page-shortid);
+    container: li;
+    class: os-toc-counted-page; }
+
+:pass(11) body > div[data-type="chapter"] > [data-type="composite-chapter"] > [data-type='document-title'], :pass(11) body > div[data-type="composite-chapter"] > [data-type="composite-chapter"] > [data-type='document-title'] {
+  node-set: CchapterTitle;
+  string-set: CchapTitle-id attr(id); }
+
+:pass(11) body > div[data-type="chapter"] > [data-type="composite-chapter"] > [data-type='metadata']
+> [data-type='cnx-archive-shortid'], :pass(11) body > div[data-type="composite-chapter"] > [data-type="composite-chapter"] > [data-type='metadata']
+> [data-type='cnx-archive-shortid'] {
+  string-set: Cchap-shortid attr(data-value); }
+
+:pass(11) body > div[data-type="chapter"] > [data-type="composite-chapter"]::after, :pass(11) body > div[data-type="composite-chapter"] > [data-type="composite-chapter"]::after {
+  content: nodes(CchapterTitle);
+  attr-href: "#" string(CchapTitle-id);
+  container: a;
+  move-to: cc-link; }
+
+:pass(11) body > div[data-type="chapter"] > [data-type="composite-chapter"] > div[data-type="composite-page"], :pass(11) body > div[data-type="composite-chapter"] > [data-type="composite-chapter"] > div[data-type="composite-page"] {
+  string-set: Cpage-id-chap attr(id); }
+  :pass(11) body > div[data-type="chapter"] > [data-type="composite-chapter"] > div[data-type="composite-page"] > [data-type='title'], :pass(11) body > div[data-type="composite-chapter"] > [data-type="composite-chapter"] > div[data-type="composite-page"] > [data-type='title'] {
+    node-set: CPageTitle; }
+  :pass(11) body > div[data-type="chapter"] > [data-type="composite-chapter"] > div[data-type="composite-page"] > [data-type='metadata']
+> [data-type='cnx-archive-shortid'], :pass(11) body > div[data-type="composite-chapter"] > [data-type="composite-chapter"] > div[data-type="composite-page"] > [data-type='metadata']
+> [data-type='cnx-archive-shortid'] {
+    string-set: Cpage-shortid attr(data-value); }
+  :pass(11) body > div[data-type="chapter"] > [data-type="composite-chapter"] > div[data-type="composite-page"]::after, :pass(11) body > div[data-type="composite-chapter"] > [data-type="composite-chapter"] > div[data-type="composite-page"]::after {
+    content: nodes(CPageTitle);
+    attr-href: "#" string(Cpage-shortid);
+    container: a;
+    move-to: CpageLink; }
+  :pass(11) body > div[data-type="chapter"] > [data-type="composite-chapter"] > div[data-type="composite-page"]::after, :pass(11) body > div[data-type="composite-chapter"] > [data-type="composite-chapter"] > div[data-type="composite-page"]::after {
+    content: pending(CpageLink);
+    attr-cnx-archive-uri: attr(id);
+    attr-cnx-archive-shortid: string(page-shortid);
+    container: li;
+    move-to: Cpage-list; }
+
+:pass(11) body > div[data-type="chapter"] > [data-type="composite-chapter"]::after, :pass(11) body > div[data-type="composite-chapter"] > [data-type="composite-chapter"]::after {
+  content: pending(Cpage-list);
+  attr-cnx-archive-uri: attr(id);
+  attr-cnx-archive-shortid: string(page-shortid);
+  container: ol;
+  move-to: cc-li; }
+
+:pass(11) body > div[data-type="chapter"] > [data-type="composite-chapter"]::after, :pass(11) body > div[data-type="composite-chapter"] > [data-type="composite-chapter"]::after {
+  content: pending(cc-link) pending(cc-li);
+  container: li;
+  move-to: eoc-toc-pages; }
+
+:pass(11) body > div[data-type="chapter"] > [data-type='document-title'], :pass(11) body > div[data-type="composite-chapter"] > [data-type='document-title'] {
+  node-set: chapterTitle;
+  string-set: chapTitle-id attr(id); }
+
+:pass(11) body > div[data-type="chapter"] > [data-type='metadata']
+> [data-type='cnx-archive-shortid'], :pass(11) body > div[data-type="composite-chapter"] > [data-type='metadata']
+> [data-type='cnx-archive-shortid'] {
+  string-set: chap-shortid attr(data-value); }
+
+:pass(11) body > div[data-type="chapter"]::after, :pass(11) body > div[data-type="composite-chapter"]::after {
+  content: nodes(chapterTitle);
+  attr-href: "#" string(chapTitle-id);
+  container: a;
+  move-to: eoc-toc; }
+
+:pass(11) body > div[data-type="chapter"] > div[data-type="page"],
+:pass(11) body > div[data-type="chapter"] > div[data-type="composite-page"], :pass(11) body > div[data-type="composite-chapter"] > div[data-type="page"],
+:pass(11) body > div[data-type="composite-chapter"] > div[data-type="composite-page"] {
+  string-set: page-id-chap attr(id); }
+  :pass(11) body > div[data-type="chapter"] > div[data-type="page"] > [data-type='document-title'],
+  :pass(11) body > div[data-type="chapter"] > div[data-type="composite-page"] > [data-type='document-title'], :pass(11) body > div[data-type="composite-chapter"] > div[data-type="page"] > [data-type='document-title'],
+  :pass(11) body > div[data-type="composite-chapter"] > div[data-type="composite-page"] > [data-type='document-title'] {
+    node-set: PageTitle; }
+  :pass(11) body > div[data-type="chapter"] > div[data-type="page"] > [data-type='metadata']
+> [data-type='cnx-archive-shortid'],
+  :pass(11) body > div[data-type="chapter"] > div[data-type="composite-page"] > [data-type='metadata']
+> [data-type='cnx-archive-shortid'], :pass(11) body > div[data-type="composite-chapter"] > div[data-type="page"] > [data-type='metadata']
+> [data-type='cnx-archive-shortid'],
+  :pass(11) body > div[data-type="composite-chapter"] > div[data-type="composite-page"] > [data-type='metadata']
+> [data-type='cnx-archive-shortid'] {
+    string-set: page-shortid attr(data-value); }
+  :pass(11) body > div[data-type="chapter"] > div[data-type="page"]::after,
+  :pass(11) body > div[data-type="chapter"] > div[data-type="composite-page"]::after, :pass(11) body > div[data-type="composite-chapter"] > div[data-type="page"]::after,
+  :pass(11) body > div[data-type="composite-chapter"] > div[data-type="composite-page"]::after {
+    content: nodes(PageTitle);
+    attr-href: "#" string(page-id-chap);
+    container: a;
+    move-to: page-link; }
+  :pass(11) body > div[data-type="chapter"] > div[data-type="page"]::after,
+  :pass(11) body > div[data-type="chapter"] > div[data-type="composite-page"]::after, :pass(11) body > div[data-type="composite-chapter"] > div[data-type="page"]::after,
+  :pass(11) body > div[data-type="composite-chapter"] > div[data-type="composite-page"]::after {
+    content: pending(page-link);
+    move-to: eoc-toc-pages;
+    attr-cnx-archive-uri: attr(id);
+    attr-cnx-archive-shortid: string(page-shortid);
+    container: li; }
+
+:pass(11) body > div[data-type="chapter"]::after, :pass(11) body > div[data-type="composite-chapter"]::after {
+  content: pending(eoc-toc-pages);
+  container: ol;
+  class: os-chapter;
+  move-to: eoc-toc; }
+
+:pass(11) body > div[data-type="chapter"]::after, :pass(11) body > div[data-type="composite-chapter"]::after {
+  content: pending(eoc-toc);
+  attr-cnx-archive-uri: attr(id);
+  attr-cnx-archive-shortid: string(chap-shortid);
+  container: li;
+  move-to: eob-toc; }
+
+:pass(11) body > div[data-type="unit"] > [data-type='document-title'] {
+  node-set: unitTitle;
+  string-set: uTitle-id attr(id); }
+
+:pass(11) body > div[data-type="unit"] > [data-type='metadata']
+> [data-type='cnx-archive-shortid'] {
+  string-set: unit-shortid attr(data-value); }
+
+:pass(11) body > div[data-type="unit"]::after {
+  content: nodes(unitTitle);
+  attr-href: "#" string(uTitle-id);
+  container: a;
+  move-to: eou-toc; }
+
+:pass(11) body > div[data-type="unit"] > div[data-type="chapter"] > [data-type="composite-chapter"] > [data-type='document-title'], :pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"] > [data-type="composite-chapter"] > [data-type='document-title'] {
+  node-set: CchapterTitle;
+  string-set: CchapTitle-id attr(id); }
+
+:pass(11) body > div[data-type="unit"] > div[data-type="chapter"] > [data-type="composite-chapter"] > [data-type='metadata']
+> [data-type='cnx-archive-shortid'], :pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"] > [data-type="composite-chapter"] > [data-type='metadata']
+> [data-type='cnx-archive-shortid'] {
+  string-set: Cchap-shortid attr(data-value); }
+
+:pass(11) body > div[data-type="unit"] > div[data-type="chapter"] > [data-type="composite-chapter"]::after, :pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"] > [data-type="composite-chapter"]::after {
+  content: nodes(CchapterTitle);
+  attr-href: "#" string(CchapTitle-id);
+  container: a;
+  move-to: cc-link; }
+
+:pass(11) body > div[data-type="unit"] > div[data-type="chapter"] > [data-type="composite-chapter"] > div[data-type="composite-page"], :pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"] > [data-type="composite-chapter"] > div[data-type="composite-page"] {
+  string-set: Cpage-id-chap attr(id); }
+  :pass(11) body > div[data-type="unit"] > div[data-type="chapter"] > [data-type="composite-chapter"] > div[data-type="composite-page"] > [data-type='title'], :pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"] > [data-type="composite-chapter"] > div[data-type="composite-page"] > [data-type='title'] {
+    node-set: CPageTitle; }
+  :pass(11) body > div[data-type="unit"] > div[data-type="chapter"] > [data-type="composite-chapter"] > div[data-type="composite-page"] > [data-type='metadata']
+> [data-type='cnx-archive-shortid'], :pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"] > [data-type="composite-chapter"] > div[data-type="composite-page"] > [data-type='metadata']
+> [data-type='cnx-archive-shortid'] {
+    string-set: Cpage-shortid attr(data-value); }
+  :pass(11) body > div[data-type="unit"] > div[data-type="chapter"] > [data-type="composite-chapter"] > div[data-type="composite-page"]::after, :pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"] > [data-type="composite-chapter"] > div[data-type="composite-page"]::after {
+    content: nodes(CPageTitle);
+    attr-href: "#" string(Cpage-shortid);
+    container: a;
+    move-to: CpageLink; }
+  :pass(11) body > div[data-type="unit"] > div[data-type="chapter"] > [data-type="composite-chapter"] > div[data-type="composite-page"]::after, :pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"] > [data-type="composite-chapter"] > div[data-type="composite-page"]::after {
+    content: pending(CpageLink);
+    attr-cnx-archive-uri: attr(id);
+    attr-cnx-archive-shortid: string(page-shortid);
+    container: li;
+    move-to: Cpage-list; }
+
+:pass(11) body > div[data-type="unit"] > div[data-type="chapter"] > [data-type="composite-chapter"]::after, :pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"] > [data-type="composite-chapter"]::after {
+  content: pending(Cpage-list);
+  attr-cnx-archive-uri: attr(id);
+  attr-cnx-archive-shortid: string(page-shortid);
+  container: ol;
+  move-to: cc-li; }
+
+:pass(11) body > div[data-type="unit"] > div[data-type="chapter"] > [data-type="composite-chapter"]::after, :pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"] > [data-type="composite-chapter"]::after {
+  content: pending(cc-link) pending(cc-li);
+  container: li;
+  move-to: eoc-toc-pages; }
+
+:pass(11) body > div[data-type="unit"] > div[data-type="chapter"] > [data-type='document-title'], :pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"] > [data-type='document-title'] {
+  node-set: chapterTitle;
+  string-set: chapTitle-id attr(id); }
+
+:pass(11) body > div[data-type="unit"] > div[data-type="chapter"] > [data-type='metadata']
+> [data-type='cnx-archive-shortid'], :pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"] > [data-type='metadata']
+> [data-type='cnx-archive-shortid'] {
+  string-set: chap-shortid attr(data-value); }
+
+:pass(11) body > div[data-type="unit"] > div[data-type="chapter"]::after, :pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"]::after {
+  content: nodes(chapterTitle);
+  attr-href: "#" string(chapTitle-id);
+  container: a;
+  move-to: eoc-toc; }
+
+:pass(11) body > div[data-type="unit"] > div[data-type="chapter"] > div[data-type="page"],
+:pass(11) body > div[data-type="unit"] > div[data-type="chapter"] > div[data-type="composite-page"], :pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"] > div[data-type="page"],
+:pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"] > div[data-type="composite-page"] {
+  string-set: page-id-chap attr(id); }
+  :pass(11) body > div[data-type="unit"] > div[data-type="chapter"] > div[data-type="page"] > [data-type='document-title'],
+  :pass(11) body > div[data-type="unit"] > div[data-type="chapter"] > div[data-type="composite-page"] > [data-type='document-title'], :pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"] > div[data-type="page"] > [data-type='document-title'],
+  :pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"] > div[data-type="composite-page"] > [data-type='document-title'] {
+    node-set: PageTitle; }
+  :pass(11) body > div[data-type="unit"] > div[data-type="chapter"] > div[data-type="page"] > [data-type='metadata']
+> [data-type='cnx-archive-shortid'],
+  :pass(11) body > div[data-type="unit"] > div[data-type="chapter"] > div[data-type="composite-page"] > [data-type='metadata']
+> [data-type='cnx-archive-shortid'], :pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"] > div[data-type="page"] > [data-type='metadata']
+> [data-type='cnx-archive-shortid'],
+  :pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"] > div[data-type="composite-page"] > [data-type='metadata']
+> [data-type='cnx-archive-shortid'] {
+    string-set: page-shortid attr(data-value); }
+  :pass(11) body > div[data-type="unit"] > div[data-type="chapter"] > div[data-type="page"]::after,
+  :pass(11) body > div[data-type="unit"] > div[data-type="chapter"] > div[data-type="composite-page"]::after, :pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"] > div[data-type="page"]::after,
+  :pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"] > div[data-type="composite-page"]::after {
+    content: nodes(PageTitle);
+    attr-href: "#" string(page-id-chap);
+    container: a;
+    move-to: page-link; }
+  :pass(11) body > div[data-type="unit"] > div[data-type="chapter"] > div[data-type="page"]::after,
+  :pass(11) body > div[data-type="unit"] > div[data-type="chapter"] > div[data-type="composite-page"]::after, :pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"] > div[data-type="page"]::after,
+  :pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"] > div[data-type="composite-page"]::after {
+    content: pending(page-link);
+    move-to: eoc-toc-pages;
+    attr-cnx-archive-uri: attr(id);
+    attr-cnx-archive-shortid: string(page-shortid);
+    container: li; }
+
+:pass(11) body > div[data-type="unit"] > div[data-type="chapter"]::after, :pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"]::after {
+  content: pending(eoc-toc-pages);
+  container: ol;
+  class: os-chapter;
+  move-to: eoc-toc; }
+
+:pass(11) body > div[data-type="unit"] > div[data-type="chapter"]::after, :pass(11) body > div[data-type="unit"] > div[data-type="composite-chapter"]::after {
+  content: pending(eoc-toc);
+  attr-cnx-archive-uri: attr(id);
+  attr-cnx-archive-shortid: string(chap-shortid);
+  container: li;
+  move-to: eou-toc-chapters; }
+
+:pass(11) body > div[data-type="unit"]::after {
+  content: pending(eou-toc-chapters);
+  container: ol;
+  class: os-unit;
+  move-to: eou-toc; }
+
+:pass(11) body > div[data-type="unit"]::after {
+  content: pending(eou-toc);
+  attr-cnx-archive-uri: attr(id);
+  attr-cnx-archive-shortid: string(unit-shortid);
+  container: li;
+  move-to: eob-toc; }
+
+:pass(11) div.os-table table[summary] {
+  attr-summary: string(tableSummary); }
+
+:pass(11) div.temp-summary {
+  string-set: tableSummary content();
+  move-to: trash; }
+
+:pass(12) nav#toc {
+  content: ''; }
+  :pass(12) nav#toc::after {
+    content: pending(eob-toc);
+    container: ol; }
+
+:pass(13) nav#toc li > a > h1 > span,
+:pass(13) nav#toc li > a > h2 > span,
+:pass(13) nav#toc li > a > h3 > span,
+:pass(13) nav#toc li > a > div > span {
+  move-to: title-spans; }
+
+:pass(13) nav#toc li > a:deferred {
+  content: pending(title-spans); }
+
+:pass(100) div.delete-me {
+  move-to: trash; }
+
+:pass(100) body:deferred::after {
+  content: clear(trash); }
+
+/*# sourceMappingURL=business-ethics.css.map */

--- a/bakery/src/tests/test_cli.js
+++ b/bakery/src/tests/test_cli.js
@@ -16,22 +16,92 @@ const completion = subprocess => {
   })
 }
 
-test('test', async t => {
+test('stable flow in content distribution pipeline', async t => {
+  // Prepare test data
   const bookId = 'col30149'
   const outputDir = 'src/tests/output'
+  const dataDir = 'src/tests/data'
   try {
     await fs.rmdir(outputDir, { recursive: true })
   } catch {}
-  await fs.copy(`src/tests/data/${bookId}`, `${outputDir}/${bookId}`)
-  const child = spawn('node', [
+  await fs.copy(`${dataDir}/${bookId}`, `${outputDir}/${bookId}`)
+
+  // Build local cops-bakery-scripts image
+  const scriptsImageBuild = spawn('docker', [
+    'build',
+    'src/scripts',
+    '--tag=localhost.localdomain:5000/openstax/cops-bakery-scripts:test'
+  ], { stdio: 'inherit' })
+  await completion(scriptsImageBuild)
+
+  const assemble = spawn('node', [
     'src/cli/execute.js',
-    '-c',
-    '..',
-    '-d',
-    outputDir,
+    '--cops=..',
+    `--data=${outputDir}`,
+    '--persist',
     'assemble',
     bookId
   ], { stdio: 'inherit' })
-  await completion(child)
+  await completion(assemble)
   t.truthy(fs.existsSync(`${outputDir}/${bookId}/assembled-book/${bookId}/collection.assembled.xhtml`))
+
+  const assembleMeta = spawn('node', [
+    'src/cli/execute.js',
+    '--cops=..',
+    `--data=${outputDir}`,
+    '--image=localhost.localdomain:5000/openstax/cops-bakery-scripts:test',
+    '--persist',
+    'assemble-meta',
+    bookId
+  ], { stdio: 'inherit' })
+  await completion(assembleMeta)
+  t.truthy(fs.existsSync(`${outputDir}/${bookId}/assembled-book-metadata/${bookId}/collection.assembled-metadata.json`))
+
+  const bake = spawn('node', [
+    'src/cli/execute.js',
+    '--cops=..',
+    `--data=${outputDir}`,
+    '--persist',
+    'bake',
+    bookId,
+    `${dataDir}/col30149-recipe.css`,
+    `${dataDir}/blank-style.css`
+  ], { stdio: 'inherit' })
+  await completion(bake)
+  t.truthy(fs.existsSync(`${outputDir}/${bookId}/baked-book/${bookId}/collection.baked.xhtml`))
+
+  const bakeMeta = spawn('node', [
+    'src/cli/execute.js',
+    '--cops=..',
+    `--data=${outputDir}`,
+    '--image=localhost.localdomain:5000/openstax/cops-bakery-scripts:test',
+    '--persist',
+    'bake-meta',
+    bookId
+  ], { stdio: 'inherit' })
+  await completion(bakeMeta)
+  t.truthy(fs.existsSync(`${outputDir}/${bookId}/baked-book-metadata/${bookId}/collection.baked-metadata.json`))
+
+  const disassemble = spawn('node', [
+    'src/cli/execute.js',
+    '--cops=..',
+    `--data=${outputDir}`,
+    '--image=localhost.localdomain:5000/openstax/cops-bakery-scripts:test',
+    '--persist',
+    'disassemble',
+    bookId
+  ], { stdio: 'inherit' })
+  await completion(disassemble)
+  t.truthy(fs.existsSync(`${outputDir}/${bookId}/disassembled-book/${bookId}/disassembled/collection.toc.xhtml`))
+
+  const jsonify = spawn('node', [
+    'src/cli/execute.js',
+    '--cops=..',
+    `--data=${outputDir}`,
+    '--image=localhost.localdomain:5000/openstax/cops-bakery-scripts:test',
+    'jsonify',
+    bookId
+  ], { stdio: 'inherit' })
+  await completion(jsonify)
+  t.truthy(fs.existsSync(`${outputDir}/${bookId}/jsonified-book/${bookId}/jsonified/collection.toc.json`))
 })


### PR DESCRIPTION
A couple things landed here:
- Expanded the CLI functional test to cover the distribution pipeline
- Build and use in the CLI an image from the checked out source rather than what's on docker hub (which is MUCH better for PR checks, since it will actually test the code in the PR)
- Make sure to sync before login, so that concourse upgrades don't break everything.
- The CLI now exits with a non-zero code when an error occurs (good for fail fast behavior, and getting expected results when chaining CLI calls)

Not done here:
- Covering the pdf pipeline. Can be done in a different PR, there's already probably too much in this one.