### PR TITLE
Add --tag option for pipelines and tasks

### DIFF
--- a/bakery/src/pipeline.js
+++ b/bakery/src/pipeline.js
@@ -4,21 +4,21 @@ const yaml = require('js-yaml')
 
 const pipelineDir = path.resolve(__dirname, './pipelines')
 const envDir = path.resolve(__dirname, '../env')
-const commandUsage = 'pipeline <pipelinetype> [options] <env> [options]...'	
+const commandUsage = 'pipeline <pipelinetype> <env> [options]...'	
 
 module.exports.command = commandUsage
 module.exports.aliases = ['p']
 module.exports.describe = 'builds a pipeline runnable with fly command'
 module.exports.builder = yargs => {	
   yargs.usage(`Usage: ${process.env.CALLER || 'build.js'} ${commandUsage}`)	
-  yargs.positional('env', {
-    describe: 'name of environment',
-    choices: fs.readdirSync(envDir).map(file => path.basename(file, '.json')),
-    type: 'string'
-  }).positional('pipelinetype', {	
+  yargs.positional('pipelinetype', {	
     describe: 'type of pipeline',	
     choices: fs.readdirSync(pipelineDir).map(file => path.basename(file, '.js')),	
     type: 'string'	
+  }).positional('env', {
+    describe: 'name of environment',
+    choices: fs.readdirSync(envDir).map(file => path.basename(file, '.json')),
+    type: 'string'
   }).option('output', {	
     alias: ['o'],	
     describe: 'path to output file',	
@@ -26,10 +26,9 @@ module.exports.builder = yargs => {
     normalize: true,	
     requiresArg: true,	
     type: 'string'	
-  }).option('pipelinetypeargs', {
-    alias: ['a'],
-    describe: 'args for pipeline type',
-    requiresArg: true,
+  }).option('tag', {
+    alias: ['t'],
+    describe: 'pin pipeline image resources to a tag in the config',
     type: 'string'
   })
 }
@@ -41,23 +40,21 @@ module.exports.handler = argv => {
     } catch {
       throw new Error(`Could not find environment file: ${envFilePath}`)
     }
-  })()
-  const pipeline = ((env) => {
+  }).call()
+  const pipeline = (() => {
     const pipelineFilePath = path.resolve(pipelineDir, `${argv.pipelinetype}.js`)
     try {
       return require(pipelineFilePath)
     } catch {
       throw new Error(`Could not find pipeline file: ${pipelineFilePath}`)
     }
-  })()
+  }).call()
   const outputFile = argv.output == null
     ? undefined
     : path.resolve(argv.output)
-  const pipelineArgs = argv.pipelineargs == null
-    ? {}
-    : yaml.safeLoad(argv.pipelineargs)
 
-  const pipelineConfig = pipeline(env).config
+  const pipelineArgs = argv.tag != null ? {...env, ...{IMAGE_TAG: argv.tag}} : env
+  const pipelineConfig = pipeline(pipelineArgs).config
 
   const forward = fs.readFileSync(path.resolve(__dirname, 'forward.yml'), { encoding: 'utf8' })
   const output = forward + yaml.safeDump(pipelineConfig)

--- a/bakery/src/pipelines/distribution.js
+++ b/bakery/src/pipelines/distribution.js
@@ -38,18 +38,19 @@ const pipeline = (env) => {
     plan: [
       { get: 's3-feed', trigger: true, version: 'every' },
       { get: 'cnx-recipes' },
-      taskLookUpFeed(),
-      taskFetchBook(),
-      taskAssembleBook(),
-      taskAssembleBookMeta(),
-      taskBakeBook(),
-      taskBakeBookMeta(),
-      taskDisassembleBook(),
-      taskJsonifyBook(),
+      taskLookUpFeed({ image: { tag: env.IMAGE_TAG } }),
+      taskFetchBook({ image: { tag: env.IMAGE_TAG } }),
+      taskAssembleBook({ image: { tag: env.IMAGE_TAG } }),
+      taskAssembleBookMeta({ image: { tag: env.IMAGE_TAG } }),
+      taskBakeBook({ image: { tag: env.IMAGE_TAG } }),
+      taskBakeBookMeta({ image: { tag: env.IMAGE_TAG } }),
+      taskDisassembleBook({ image: { tag: env.IMAGE_TAG } }),
+      taskJsonifyBook({ image: { tag: env.IMAGE_TAG } }),
       taskUploadBook({
         bucketName: bucket,
         awsAccessKeyId: awsAccessKeyId,
-        awsSecretAccessKey: awsSecretAccessKey
+        awsSecretAccessKey: awsSecretAccessKey,
+        image: { tag: env.IMAGE_TAG }
       })
     ]
   }

--- a/bakery/src/pipelines/pdf.js
+++ b/bakery/src/pipelines/pdf.js
@@ -32,7 +32,7 @@ const pipeline = (env) => {
       type: 'docker-image',
       source: {
         repository: 'openstax/output-producer-resource',
-        tag: '1.1.2'
+        tag: env.IMAGE_TAG || 'latest'
       }
     }
   ]
@@ -75,13 +75,13 @@ const pipeline = (env) => {
       { get: 'output-producer', trigger: true, version: 'every' },
       reportToOutputProducer(Status.ASSIGNED),
       { get: 'cnx-recipes' },
-      taskLookUpBook(),
+      taskLookUpBook({ image: { tag: env.IMAGE_TAG } }),
       reportToOutputProducer(Status.PROCESSING),
-      taskFetchBook(),
-      taskAssembleBook(),
-      taskBakeBook(),
-      taskMathifyBook(),
-      taskBuildPdf({ bucketName: env.S3_BUCKET }),
+      taskFetchBook({ image: { tag: env.IMAGE_TAG } }),
+      taskAssembleBook({ image: { tag: env.IMAGE_TAG } }),
+      taskBakeBook({ image: { tag: env.IMAGE_TAG } }),
+      taskMathifyBook({ image: { tag: env.IMAGE_TAG } }),
+      taskBuildPdf({ bucketName: env.S3_BUCKET, image: { tag: env.IMAGE_TAG } }),
       {
         put: 's3',
         params: {

--- a/bakery/src/task-util/task-util.js
+++ b/bakery/src/task-util/task-util.js
@@ -1,12 +1,14 @@
-const constructImageSource = ({ imageRegistry, imageName, imageTag }) => {
-  if (imageRegistry == null || imageName == null) {
-    return null
+const constructImageSource = ({ registry, name, tag }) => {
+  const source = {}
+  if (name == null) { return null }
+  if (tag != null) { source.tag = tag }
+  if (registry != null) {
+    source.repository = `${registry}/${name}`
+    source.insecure_registries = [registry]
+  } else {
+    source.repository = name
   }
-  return {
-    repository: `${imageRegistry}/${imageName}`,
-    tag: imageTag || 'latest',
-    insecure_registries: [imageRegistry]
-  }
+  return source
 }
 
 module.exports = {

--- a/bakery/src/tasks/assemble-book-metadata.js
+++ b/bakery/src/tasks/assemble-book-metadata.js
@@ -3,10 +3,12 @@ const dedent = require('dedent')
 const { constructImageSource } = require('../task-util/task-util')
 
 const task = (taskArgs) => {
-  const { imageRegistry, imageName, imageTag } = taskArgs == null ? {} : taskArgs
-  const imageSource = (constructImageSource({ imageRegistry, imageName, imageTag }) ||
-    { repository: 'openstax/cops-bakery-scripts' }
-  )
+  const imageDefault = {
+    name: 'openstax/cops-bakery-scripts'
+  }
+  const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
+  const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })
+
   return {
     task: 'assemble book metadata',
     config: {

--- a/bakery/src/tasks/assemble-book.js
+++ b/bakery/src/tasks/assemble-book.js
@@ -1,15 +1,21 @@
 const dedent = require('dedent')
 
-const task = () => {
+const { constructImageSource } = require('../task-util/task-util')
+
+const task = (taskArgs) => {
+  const imageDefault = {
+    name: 'openstax/nebuchadnezzar'
+  }
+  const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
+  const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })
+
   return {
     task: 'assemble book',
     config: {
       platform: 'linux',
       image_resource: {
         type: 'docker-image',
-        source: {
-          repository: 'openstax/nebuchadnezzar'
-        }
+        source: imageSource
       },
       inputs: [
         { name: 'book' },

--- a/bakery/src/tasks/bake-book-metadata.js
+++ b/bakery/src/tasks/bake-book-metadata.js
@@ -3,12 +3,12 @@ const dedent = require('dedent')
 const { constructImageSource } = require('../task-util/task-util')
 
 const task = (taskArgs) => {
-  // By default, use the cops-bakery-scripts image on Docker Hub
-  // if details given, find alternative image
-  const { imageRegistry, imageName, imageTag } = taskArgs == null ? {} : taskArgs
-  const imageSource = (constructImageSource({ imageRegistry, imageName, imageTag }) ||
-    { repository: 'openstax/cops-bakery-scripts' }
-  )
+  const imageDefault = {
+    name: 'openstax/cops-bakery-scripts'
+  }
+  const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
+  const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })
+
   return {
     task: 'bake book metadata',
     config: {

--- a/bakery/src/tasks/bake-book.js
+++ b/bakery/src/tasks/bake-book.js
@@ -1,15 +1,21 @@
 const dedent = require('dedent')
 
-const task = () => {
+const { constructImageSource } = require('../task-util/task-util')
+
+const task = (taskArgs) => {
+  const imageDefault = {
+    name: 'openstax/cnx-easybake'
+  }
+  const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
+  const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })
+
   return {
     task: 'bake book',
     config: {
       platform: 'linux',
       image_resource: {
         type: 'docker-image',
-        source: {
-          repository: 'openstax/cnx-easybake'
-        }
+        source: imageSource
       },
       inputs: [
         { name: 'book' },

--- a/bakery/src/tasks/build-pdf.js
+++ b/bakery/src/tasks/build-pdf.js
@@ -1,15 +1,22 @@
 const dedent = require('dedent')
 
-const task = ({ bucketName }) => {
+const { constructImageSource } = require('../task-util/task-util')
+
+const task = (taskArgs) => {
+  const { bucketName } = taskArgs
+  const imageDefault = {
+    name: 'openstax/princexml'
+  }
+  const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
+  const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })
+
   return {
     task: 'build pdf',
     config: {
       platform: 'linux',
       image_resource: {
         type: 'docker-image',
-        source: {
-          repository: 'openstax/princexml'
-        }
+        source: imageSource
       },
       inputs: [
         { name: 'book' },

--- a/bakery/src/tasks/check-feed.js
+++ b/bakery/src/tasks/check-feed.js
@@ -1,15 +1,22 @@
 const dedent = require('dedent')
 
-const task = ({ awsAccessKeyId, awsSecretAccessKey, bucketName, feedFileUrl }) => {
+const { constructImageSource } = require('../task-util/task-util')
+
+const task = (taskArgs) => {
+  const { awsAccessKeyId, awsSecretAccessKey, bucketName, feedFileUrl } = taskArgs
+  const imageDefault = {
+    name: 'openstax/cops-bakery-scripts'
+  }
+  const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
+  const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })
+
   return {
     task: 'check feed',
     config: {
       platform: 'linux',
       image_resource: {
         type: 'docker-image',
-        source: {
-          repository: 'openstax/cops-bakery-scripts'
-        }
+        source: imageSource
       },
       params: {
         AWS_ACCESS_KEY_ID: `${awsAccessKeyId}`,

--- a/bakery/src/tasks/disassemble-book.js
+++ b/bakery/src/tasks/disassemble-book.js
@@ -3,10 +3,12 @@ const dedent = require('dedent')
 const { constructImageSource } = require('../task-util/task-util')
 
 const task = (taskArgs) => {
-  const { imageRegistry, imageName, imageTag } = taskArgs == null ? {} : taskArgs
-  const imageSource = (constructImageSource({ imageRegistry, imageName, imageTag }) ||
-    { repository: 'openstax/cops-bakery-scripts' }
-  )
+  const imageDefault = {
+    name: 'openstax/cops-bakery-scripts'
+  }
+  const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
+  const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })
+
   return {
     task: 'disassemble book',
     config: {

--- a/bakery/src/tasks/fetch-book.js
+++ b/bakery/src/tasks/fetch-book.js
@@ -1,15 +1,21 @@
 const dedent = require('dedent')
 
-const task = () => {
+const { constructImageSource } = require('../task-util/task-util')
+
+const task = (taskArgs) => {
+  const imageDefault = {
+    name: 'openstax/nebuchadnezzar'
+  }
+  const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
+  const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })
+
   return {
     task: 'fetch book',
     config: {
       platform: 'linux',
       image_resource: {
         type: 'docker-image',
-        source: {
-          repository: 'openstax/nebuchadnezzar'
-        }
+        source: imageSource
       },
       inputs: [{ name: 'book' }],
       outputs: [{ name: 'fetched-book' }],

--- a/bakery/src/tasks/jsonify-book.js
+++ b/bakery/src/tasks/jsonify-book.js
@@ -3,12 +3,12 @@ const dedent = require('dedent')
 const { constructImageSource } = require('../task-util/task-util')
 
 const task = (taskArgs) => {
-  // By default, use the cops-bakery-scripts image on Docker Hub
-  // if details given, find alternative image
-  const { imageRegistry, imageName, imageTag } = taskArgs == null ? {} : taskArgs
-  const imageSource = (constructImageSource({ imageRegistry, imageName, imageTag }) ||
-    { repository: 'openstax/cops-bakery-scripts' }
-  )
+  const imageDefault = {
+    name: 'openstax/cops-bakery-scripts'
+  }
+  const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
+  const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })
+
   return {
     task: 'jsonify book',
     config: {

--- a/bakery/src/tasks/look-up-book.js
+++ b/bakery/src/tasks/look-up-book.js
@@ -1,15 +1,21 @@
 const dedent = require('dedent')
 
-const task = () => {
+const { constructImageSource } = require('../task-util/task-util')
+
+const task = (taskArgs) => {
+  const imageDefault = {
+    name: 'openstax/nebuchadnezzar'
+  }
+  const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
+  const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })
+
   return {
     task: 'look up book',
     config: {
       platform: 'linux',
       image_resource: {
         type: 'docker-image',
-        source: {
-          repository: 'openstax/nebuchadnezzar'
-        }
+        source: imageSource
       },
       inputs: [{ name: 'output-producer' }],
       outputs: [{ name: 'book' }],

--- a/bakery/src/tasks/look-up-feed.js
+++ b/bakery/src/tasks/look-up-feed.js
@@ -1,15 +1,21 @@
 const dedent = require('dedent')
 
-const task = () => {
+const { constructImageSource } = require('../task-util/task-util')
+
+const task = (taskArgs) => {
+  const imageDefault = {
+    name: 'openstax/cops-bakery-scripts'
+  }
+  const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
+  const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })
+
   return {
     task: 'look up feed',
     config: {
       platform: 'linux',
       image_resource: {
         type: 'docker-image',
-        source: {
-          repository: 'openstax/cops-bakery-scripts'
-        }
+        source: imageSource
       },
       inputs: [{ name: 's3-feed' }],
       outputs: [{ name: 'book' }],

--- a/bakery/src/tasks/mathify-book.js
+++ b/bakery/src/tasks/mathify-book.js
@@ -1,15 +1,21 @@
 const dedent = require('dedent')
 
-const task = () => {
+const { constructImageSource } = require('../task-util/task-util')
+
+const task = (taskArgs) => {
+  const imageDefault = {
+    name: 'openstax/mathify'
+  }
+  const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
+  const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })
+
   return {
     task: 'mathify book',
     config: {
       platform: 'linux',
       image_resource: {
         type: 'docker-image',
-        source: {
-          repository: 'openstax/mathify'
-        }
+        source: imageSource
       },
       inputs: [
         { name: 'book' },

--- a/bakery/src/tasks/upload-book.js
+++ b/bakery/src/tasks/upload-book.js
@@ -1,15 +1,22 @@
 const dedent = require('dedent')
 
-const task = ({ awsAccessKeyId, awsSecretAccessKey, bucketName }) => {
+const { constructImageSource } = require('../task-util/task-util')
+
+const task = (taskArgs) => {
+  const { awsAccessKeyId, awsSecretAccessKey, bucketName } = taskArgs
+  const imageDefault = {
+    name: 'openstax/cops-bakery-scripts'
+  }
+  const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
+  const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })
+
   return {
     task: 'upload book',
     config: {
       platform: 'linux',
       image_resource: {
         type: 'docker-image',
-        source: {
-          repository: 'openstax/cops-bakery-scripts'
-        }
+        source: imageSource
       },
       params: {
         AWS_ACCESS_KEY_ID: `${awsAccessKeyId}`,


### PR DESCRIPTION
This will allow us to pin pipelines to code versions via pinning each task in a pipeline to a (hopefully immutable) docker image tag.