### PR TITLE
Log heartbeat to prevent CI timeout

### DIFF
--- a/bakery/src/tests/test_cli.js
+++ b/bakery/src/tests/test_cli.js
@@ -120,6 +120,12 @@ test('stable flow in pdf and distribution pipeline', async t => {
   ])
   await completion(scriptsImageBuild)
 
+  // Log a heartbeat every minute so CI doesn't timeout
+  setInterval(() => {
+    console.log('HEARTBEAT\n   /\\ \n__/  \\  _ \n      \\/')
+  }, 60000)
+
+  // Start running tasks
   const assemble = spawn('node', [
     'src/cli/execute.js',
     ...commonArgs,


### PR DESCRIPTION
Occasionally the CLI functional test job will last longer than the CircleCI timeout time of 10m. This logs a heartbeat every minute the test is running to prevent CircleCI from ending the test with a timeout.

The heartbeat message is just some quick ascii art:
```
HEARTBEAT
   /\ 
__/  \  _ 
      \/
```