### PR TITLE
Update distribution pipeline to use a prefix on uploads

### DIFF
--- a/bakery/env/local.json
+++ b/bakery/env/local.json
@@ -1,7 +1,7 @@
 {
   "ENV_NAME": "local",
   "COPS_TARGET": "http://backend/api",
-  "S3_BUCKET": "my-bucket",
+  "S3_PDF_BUCKET": "my-bucket",
   "S3_ACCESS_KEY_ID": "",
   "S3_SECRET_ACCESS_KEY": "",
   "S3_DIST_BUCKET": "",

--- a/bakery/env/prod.json
+++ b/bakery/env/prod.json
@@ -2,5 +2,6 @@
   "ENV_NAME": "production",
   "COPS_TARGET": "https://cops.openstax.org/api",
   "S3_BUCKET": "ce-pdf-spike",
-  "S3_DIST_BUCKET": "ce-contents-cops-distribution-373045849756"
+  "S3_DIST_BUCKET": "ce-contents-cops-distribution-373045849756",
+  "VERSIONED_FILE": ""
 }

--- a/bakery/env/prod.json
+++ b/bakery/env/prod.json
@@ -1,7 +1,7 @@
 {
   "ENV_NAME": "production",
   "COPS_TARGET": "https://cops.openstax.org/api",
-  "S3_BUCKET": "ce-pdf-spike",
+  "S3_PDF_BUCKET": "ce-pdf-spike",
   "S3_DIST_BUCKET": "ce-contents-cops-distribution-373045849756",
   "VERSIONED_FILE": ""
 }

--- a/bakery/env/staging.json
+++ b/bakery/env/staging.json
@@ -2,5 +2,6 @@
   "ENV_NAME": "staging",
   "COPS_TARGET": "https://cops-staging.openstax.org/api",
   "S3_BUCKET": "ce-cops-staging",
-  "S3_DIST_BUCKET": ""
+  "S3_DIST_BUCKET": "",
+  "VERSIONED_FILE": ""
 }

--- a/bakery/env/staging.json
+++ b/bakery/env/staging.json
@@ -1,7 +1,7 @@
 {
   "ENV_NAME": "staging",
   "COPS_TARGET": "https://cops-staging.openstax.org/api",
-  "S3_BUCKET": "ce-cops-staging",
+  "S3_PDF_BUCKET": "ce-cops-staging",
   "S3_DIST_BUCKET": "",
   "VERSIONED_FILE": ""
 }

--- a/bakery/src/pipelines/distribution.js
+++ b/bakery/src/pipelines/distribution.js
@@ -28,7 +28,7 @@ const pipeline = (env) => {
       type: 's3',
       source: {
         bucket: bucket,
-        versioned_file: env.ENV_NAME === 'local' ? env.VERSIONED_FILE : '((versioned-feed-file))',
+        versioned_file: env.VERSIONED_FILE,
         access_key_id: awsAccessKeyId,
         secret_access_key: awsSecretAccessKey
       }
@@ -40,7 +40,10 @@ const pipeline = (env) => {
     plan: [
       { get: 's3-feed', trigger: true, version: 'every' },
       { get: 'cnx-recipes-output' },
-      taskLookUpFeed({ image: { tag: env.IMAGE_TAG } }),
+      taskLookUpFeed({
+        versionedFile: env.VERSIONED_FILE,
+        image: { tag: env.IMAGE_TAG }
+      }),
       taskFetchBook({ image: { tag: env.IMAGE_TAG } }),
       taskAssembleBook({ image: { tag: env.IMAGE_TAG } }),
       taskAssembleBookMeta({ image: { tag: env.IMAGE_TAG } }),

--- a/bakery/src/pipelines/distribution.js
+++ b/bakery/src/pipelines/distribution.js
@@ -10,7 +10,6 @@ const pipeline = (env) => {
   const taskJsonifyBook = require('../tasks/jsonify-book')
   const taskUploadBook = require('../tasks/upload-book')
 
-  const bucket = env.ENV_NAME === 'local' ? env.S3_DIST_BUCKET : '((aws-s3-distribution-bucket))'
   const awsAccessKeyId = env.ENV_NAME === 'local' ? env.S3_ACCESS_KEY_ID : '((aws-sandbox-secret-key-id))'
   const awsSecretAccessKey = env.ENV_NAME === 'local' ? env.S3_SECRET_ACCESS_KEY : '((aws-sandbox-secret-access-key))'
 
@@ -27,7 +26,7 @@ const pipeline = (env) => {
       name: 's3-feed',
       type: 's3',
       source: {
-        bucket: bucket,
+        bucket: env.S3_DIST_BUCKET,
         versioned_file: env.VERSIONED_FILE,
         access_key_id: awsAccessKeyId,
         secret_access_key: awsSecretAccessKey
@@ -53,7 +52,7 @@ const pipeline = (env) => {
       taskDisassembleBook({ image: { tag: env.IMAGE_TAG } }),
       taskJsonifyBook({ image: { tag: env.IMAGE_TAG } }),
       taskUploadBook({
-        bucketName: bucket,
+        bucketName: env.S3_DIST_BUCKET,
         awsAccessKeyId: awsAccessKeyId,
         awsSecretAccessKey: awsSecretAccessKey,
         image: { tag: env.IMAGE_TAG }

--- a/bakery/src/pipelines/pdf.js
+++ b/bakery/src/pipelines/pdf.js
@@ -58,7 +58,7 @@ const pipeline = (env) => {
       name: 's3',
       type: 's3',
       source: {
-        bucket: env.S3_BUCKET,
+        bucket: env.S3_PDF_BUCKET,
         access_key_id: env.ENV_NAME === 'local'
           ? env.S3_ACCESS_KEY_ID
           : '((aws-sandbox-secret-key-id))',
@@ -82,7 +82,7 @@ const pipeline = (env) => {
       taskAssembleBook({ image: { tag: env.IMAGE_TAG } }),
       taskBakeBook({ image: { tag: env.IMAGE_TAG } }),
       taskMathifyBook({ image: { tag: env.IMAGE_TAG } }),
-      taskBuildPdf({ bucketName: env.S3_BUCKET, image: { tag: env.IMAGE_TAG } }),
+      taskBuildPdf({ bucketName: env.S3_PDF_BUCKET, image: { tag: env.IMAGE_TAG } }),
       {
         put: 's3',
         params: {

--- a/bakery/src/tasks/look-up-feed.js
+++ b/bakery/src/tasks/look-up-feed.js
@@ -24,7 +24,7 @@ const task = (taskArgs) => {
         args: [
           '-cxe',
           dedent`
-          exec 2> >(tee s3-feed/stderr >&2)
+          exec 2> >(tee book/stderr >&2)
           feed=s3-feed/distribution-feed.json
           echo -n "$(cat $feed | jq -r '.[-1].collection_id')" >book/collection_id
           echo -n "$(cat $feed | jq -r '.[-1].server')" >book/server

--- a/bakery/src/tasks/look-up-feed.js
+++ b/bakery/src/tasks/look-up-feed.js
@@ -3,6 +3,7 @@ const dedent = require('dedent')
 const { constructImageSource } = require('../task-util/task-util')
 
 const task = (taskArgs) => {
+  const { versionedFile } = taskArgs
   const imageDefault = {
     name: 'openstax/cops-bakery-scripts'
   }
@@ -25,7 +26,7 @@ const task = (taskArgs) => {
           '-cxe',
           dedent`
           exec 2> >(tee book/stderr >&2)
-          feed=s3-feed/distribution-feed.json
+          feed="s3-feed/${versionedFile}"
           echo -n "$(cat $feed | jq -r '.[-1].collection_id')" >book/collection_id
           echo -n "$(cat $feed | jq -r '.[-1].server')" >book/server
           echo -n "$(cat $feed | jq -r '.[-1].style')" >book/style

--- a/bakery/src/tasks/upload-book.js
+++ b/bakery/src/tasks/upload-book.js
@@ -9,6 +9,7 @@ const task = (taskArgs) => {
   }
   const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
   const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })
+  const bucketPrefix = 'apps/archive'
 
   return {
     task: 'upload book',
@@ -45,8 +46,8 @@ const task = (taskArgs) => {
           cp "$book_dir/collection.toc.xhtml" "$target_dir/$book_uuid@$book_version.xhtml"
           for jsonfile in "$book_dir/"*@*.json; do cp "$jsonfile" "$target_dir/$(basename $jsonfile)"; done;
           for xhtmlfile in "$book_dir/"*@*.xhtml; do cp "$xhtmlfile" "$target_dir/$(basename $xhtmlfile)"; done;
-          aws s3 cp --recursive "$target_dir" "s3://${bucketName}/contents"
-          python /code/scripts/copy-resources-s3.py "$resources_dir" "${bucketName}" resources
+          aws s3 cp --recursive "$target_dir" "s3://${bucketName}/${bucketPrefix}/contents"
+          python /code/scripts/copy-resources-s3.py "$resources_dir" "${bucketName}" "${bucketPrefix}/resources"
         `
         ]
       }


### PR DESCRIPTION
This PR includes the change to incorporate a prefix for our distribution S3 uploads as well as a few minor improvements including:

* Fix a minor issue in `look-up-feed` so stderr is placed in the task output
* Pass `versionedFile` value used in the S3 resource as an input to the `look-up-feed` task so they are in sync
* Make minor usage / naming changes to the PDF and distribution S3 bucket name environment variables