### PR TITLE
Remove use of neb config file in fetch-book

### DIFF
--- a/bakery/src/tasks/fetch-book.js
+++ b/bakery/src/tasks/fetch-book.js
@@ -28,13 +28,6 @@ const task = (taskArgs) => {
           exec 2> >(tee fetched-book/stderr >&2)
           cd fetched-book
           book_dir="$(cat ../book/collection_id)"
-          mkdir -p "$book_dir" ~/.config/
-          server="$(cat ../book/server)"
-          cat >~/.config/nebuchadnezzar.ini <<EOF
-          [settings]
-          [environ-$server]
-          url = https://$server
-          EOF
           yes | neb get -r -m -d "$book_dir/raw" "$(cat ../book/server)" "$(cat ../book/collection_id)" "$(cat ../book/version)"
         `
         ]


### PR DESCRIPTION
Recent improvements to `neb` allow users to invoke commands without
creating a configuration file. Specifically, this change makes use
of the fact that with those updates, if you pass a fully qualified
hostname to neb as the environment and no configuration is available
that matches, it will use the environment value as the cnx hostname.