### PR TITLE
CLI sync w/ direct download as a fallback

### DIFF
--- a/bakery/README.md
+++ b/bakery/README.md
@@ -16,9 +16,6 @@ To use the CLI, you must have all of the following already installed:
 - docker-compose
 - node >= 12.16.1
 - npm
-- concourse `fly` CLI
-    1. [install concourse locally](https://concoursetutorial.com/#getting-started)
-    1. download `fly` from http://localhost:8080 and add it to your path
 
 getting the above software installed is outside the scope of this documentation.
 

--- a/bakery/package-lock.json
+++ b/bakery/package-lock.json
@@ -843,6 +843,15 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         }
       }
     },
@@ -2090,8 +2099,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "4.0.0",
@@ -2401,11 +2409,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
-    },
-    "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -3237,14 +3240,6 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
-    "sleep": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/sleep/-/sleep-6.1.0.tgz",
-      "integrity": "sha512-Z1x4JjJxsru75Tqn8F4tnOFeEu3HjtITTsumYUiuz54sGKdISgLCek9AUlXlVVrkhltRFhNUsJDJE76SFHTDIQ==",
-      "requires": {
-        "nan": "^2.13.2"
-      }
-    },
     "slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
@@ -3779,10 +3774,9 @@
       "dev": true
     },
     "which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/bakery/package.json
+++ b/bakery/package.json
@@ -8,6 +8,7 @@
     "js-yaml": "^3.13.1",
     "tmp": "^0.1.0",
     "wait-port": "^0.2.7",
+    "which": "^2.0.2",
     "yargs": "^15.1.0"
   },
   "devDependencies": {

--- a/bakery/src/cli/docker-compose.yml
+++ b/bakery/src/cli/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - PGDATA=/database
 
   concourse:
-    image: concourse/concourse:6.0
+    image: concourse/concourse:6.1
     command: quickstart
     privileged: true
     depends_on: [concourse-db]

--- a/bakery/src/cli/execute.js
+++ b/bakery/src/cli/execute.js
@@ -137,7 +137,7 @@ const flyExecute = async (cmdArgs, { image, persist }) => {
     } catch (err) {
       console.log('current fly cli incompatible with this concourse version')
       console.log('syncing fly cli via direct download')
-      const printOldFlyVersion = spawn('fly', ['--version'])
+      const printOldFlyVersion = spawn('fly', ['--version'], { stdio: 'inherit' })
       children.push(printOldFlyVersion)
       await completion(printOldFlyVersion)
       const flyUrl = `http://localhost:8080/api/v1/cli?arch=amd64&platform=${process.platform}`
@@ -152,7 +152,7 @@ const flyExecute = async (cmdArgs, { image, persist }) => {
         }).on('error', (err) => { reject(new Error(`Connection error. Code: ${err.code || 'undefined'}`)) })
       })
       fs.writeFileSync(flyPath, newFly)
-      const printNewFlyVersion = spawn('fly', ['--version'])
+      const printNewFlyVersion = spawn('fly', ['--version'], { stdio: 'inherit' })
       children.push(printNewFlyVersion)
       await completion(printNewFlyVersion)
     }


### PR DESCRIPTION
This should help people who encounter problems syncing from concourse v4 to concourse v6.

Installing fly is also no longer a requirement to use the cli, as it will be able to download it from the concourse container that gets spun up now and stored in `$HOME/.local/bin/bakery-cli-fly`