### PR TITLE
Add stop + up commands

### DIFF
--- a/bakery/README.md
+++ b/bakery/README.md
@@ -30,7 +30,7 @@ For now, the file `src/cli/execute.js` is the entry point for the CLI, and must 
 
 For example, to fetch a book and have its contents appear in the directory `/tmp/data`, one could use the following command, with `bakery` as their working directory:
 
-`node ./src/cli/execute.js fetch -c ./.. -d /tmp/data staging.cnx.org col30149 latest`
+`node ./src/cli/execute.js run fetch -c ./.. -d /tmp/data staging.cnx.org col30149 latest`
 
 ### Bakery Concourse Pipeline Config Generator
 
@@ -102,7 +102,7 @@ For example, if one wanted to make changes to cops-bakery-scripts and have those
 2. Make the desired change in the `src/scripts/*.py` file
 3. Build the image with `docker build .`
 4. Tag the build image as `localhost:5000/openstax/cops-bakery/scripts:latest` (the prefix of `localhost:5000` is *required*, what you name and tag your image is up to you), for example, with `docker tag $(docker image ls | awk 'NR==2 {print $3}') localhost:5000/openstax/cops-bakery-scripts:latest`
-5. Run the desired pipeline step with the CLI with the `--image` flag, e.g. `node ./src/cli/execute.js assemble-meta --image localhost:5000/openstax/cops-bakery-scripts:latest -c ./.. -d /tmp/data col30149`
+5. Run the desired pipeline step with the CLI with the `--image` flag, e.g. `node ./src/cli/execute.js run assemble-meta --image localhost:5000/openstax/cops-bakery-scripts:latest -c ./.. -d /tmp/data col30149`
 
 Note: This is probably most useful for the `cops-bakery-scripts` image, but you can technically use a local version of an image like `nebuchadnezzar` as well.
 
@@ -110,7 +110,7 @@ Note: This is probably most useful for the `cops-bakery-scripts` image, but you 
 
 Both the Bakery CLI and the Pipeline Config Generator allow you to specify a tag of a remote image to use with the `--tag`. For example, if a tag, `important-tag`, has been released for each of our images, one can:
 1. Generate a pipeline pinning all versions of images to that tag with usage like `./build pipeline pdf staging --tag=important-tag`
-2. Run an individual task with the Bakery CLI using the image of that tag as the image_resource with usage like `node ./src/cli/execute.js fetch -c ./.. -d /tmp/data staging.cnx.org col30149 latest --tag=important-tag`
+2. Run an individual task with the Bakery CLI using the image of that tag as the image_resource with usage like `node ./src/cli/execute.js run fetch -c ./.. -d /tmp/data staging.cnx.org col30149 latest --tag=important-tag`
 
 #### Testing
 `npm run lint` will lint the JS files in `bakery` and `npm run test` will run regression tests on `bakery` via the CLI.

--- a/bakery/src/cli/execute.js
+++ b/bakery/src/cli/execute.js
@@ -186,7 +186,7 @@ const flyExecute = async (cmdArgs, { image, persist }) => {
 }
 
 const tasks = {
-  fetch: () => {
+  fetch: (parentCommand) => {
     const commandUsage = 'fetch <server> <collid> <version>'
     const handler = async argv => {
       const buildExec = path.resolve(argv.cops, 'bakery/build')
@@ -217,7 +217,7 @@ const tasks = {
       aliases: 'f',
       describe: 'fetch a book',
       builder: yargs => {
-        yargs.usage(`Usage: ${process.env.CALLER || '$0'} ${commandUsage}`)
+        yargs.usage(`Usage: ${process.env.CALLER || `$0 ${parentCommand}`} ${commandUsage}`)
         yargs.positional('server', {
           describe: 'content server to fetch from',
           type: 'string'
@@ -234,7 +234,7 @@ const tasks = {
       }
     }
   },
-  assemble: () => {
+  assemble: (parentCommand) => {
     const commandUsage = 'assemble <collid>'
     const handler = async argv => {
       const buildExec = path.resolve(argv.cops, 'bakery/build')
@@ -264,7 +264,7 @@ const tasks = {
       aliases: 'a',
       describe: 'assemble a book',
       builder: yargs => {
-        yargs.usage(`Usage: ${process.env.CALLER || '$0'} ${commandUsage}`)
+        yargs.usage(`Usage: ${process.env.CALLER || `$0 ${parentCommand}`} ${commandUsage}`)
         yargs.positional('collid', {
           describe: 'collection id of collection to work on',
           type: 'string'
@@ -275,7 +275,7 @@ const tasks = {
       }
     }
   },
-  bake: () => {
+  bake: (parentCommand) => {
     const commandUsage = 'bake <collid> <recipefile> <stylefile>'
     const handler = async argv => {
       const buildExec = path.resolve(argv.cops, 'bakery/build')
@@ -314,7 +314,7 @@ const tasks = {
       aliases: 'b',
       describe: 'bake a book',
       builder: yargs => {
-        yargs.usage(`Usage: ${process.env.CALLER || '$0'} ${commandUsage}`)
+        yargs.usage(`Usage: ${process.env.CALLER || `$0 ${parentCommand}`} ${commandUsage}`)
         yargs.positional('collid', {
           describe: 'collection id of collection to work on',
           type: 'string'
@@ -331,7 +331,7 @@ const tasks = {
       }
     }
   },
-  mathify: () => {
+  mathify: (parentCommand) => {
     const commandUsage = 'mathify <collid>'
     const handler = async argv => {
       const buildExec = path.resolve(argv.cops, 'bakery/build')
@@ -361,7 +361,7 @@ const tasks = {
       aliases: 'm',
       describe: 'mathify a book',
       builder: yargs => {
-        yargs.usage(`Usage: ${process.env.CALLER || '$0'} ${commandUsage}`)
+        yargs.usage(`Usage: ${process.env.CALLER || `$0 ${parentCommand}`} ${commandUsage}`)
         yargs.positional('collid', {
           describe: 'collection id of collection to work on',
           type: 'string'
@@ -372,7 +372,7 @@ const tasks = {
       }
     }
   },
-  'build-pdf': () => {
+  'build-pdf': (parentCommand) => {
     const commandUsage = 'build-pdf <collid>'
     const handler = async argv => {
       const buildExec = path.resolve(argv.cops, 'bakery/build')
@@ -401,7 +401,7 @@ const tasks = {
       aliases: 'p',
       describe: 'build a pdf from a book',
       builder: yargs => {
-        yargs.usage(`Usage: ${process.env.CALLER || '$0'} ${commandUsage}`)
+        yargs.usage(`Usage: ${process.env.CALLER || `$0 ${parentCommand}`} ${commandUsage}`)
         yargs.positional('collid', {
           describe: 'collection id of collection to work on',
           type: 'string'
@@ -412,7 +412,7 @@ const tasks = {
       }
     }
   },
-  'assemble-meta': () => {
+  'assemble-meta': (parentCommand) => {
     const commandUsage = 'assemble-meta <collid>'
     const handler = async argv => {
       const buildExec = path.resolve(argv.cops, 'bakery/build')
@@ -442,7 +442,7 @@ const tasks = {
       aliases: 'am',
       describe: 'build metadata files from an assembled book',
       builder: yargs => {
-        yargs.usage(`Usage: ${process.env.CALLER || '$0'} ${commandUsage}`)
+        yargs.usage(`Usage: ${process.env.CALLER || `$0 ${parentCommand}`} ${commandUsage}`)
         yargs.positional('collid', {
           describe: 'collection id of collection to work on',
           type: 'string'
@@ -453,7 +453,7 @@ const tasks = {
       }
     }
   },
-  'bake-meta': () => {
+  'bake-meta': (parentCommand) => {
     const commandUsage = 'bake-meta <collid>'
     const handler = async argv => {
       const buildExec = path.resolve(argv.cops, 'bakery/build')
@@ -485,7 +485,7 @@ const tasks = {
       aliases: 'bm',
       describe: 'build metadata files from a baked book',
       builder: yargs => {
-        yargs.usage(`Usage: ${process.env.CALLER || '$0'} ${commandUsage}`)
+        yargs.usage(`Usage: ${process.env.CALLER || `$0 ${parentCommand}`} ${commandUsage}`)
         yargs.positional('collid', {
           describe: 'collection id of collection to work on',
           type: 'string'
@@ -496,7 +496,7 @@ const tasks = {
       }
     }
   },
-  checksum: () => {
+  checksum: (parentCommand) => {
     // fly -t cops-dev execute -c checksum-book.yml -j bakery/bakery -i book=./data/book -i baked-book=./data/baked-book -o checksum-book=./data/checksum-book
     const commandUsage = 'checksum <collid>'
     const handler = async argv => {
@@ -527,7 +527,7 @@ const tasks = {
       aliases: 'cb',
       describe: 'checksum resources from a baked book',
       builder: yargs => {
-        yargs.usage(`Usage: ${process.env.CALLER || '$0'} ${commandUsage}`)
+        yargs.usage(`Usage: ${process.env.CALLER || `$0 ${parentCommand}`} ${commandUsage}`)
         yargs.positional('collid', {
           describe: 'collection id of collection to work on',
           type: 'string'
@@ -538,7 +538,7 @@ const tasks = {
       }
     }
   },
-  disassemble: () => {
+  disassemble: (parentCommand) => {
     const commandUsage = 'disassemble <collid>'
     const handler = async argv => {
       const buildExec = path.resolve(argv.cops, 'bakery/build')
@@ -570,7 +570,7 @@ const tasks = {
       aliases: 'd',
       describe: 'disassemble a checksummed book',
       builder: yargs => {
-        yargs.usage(`Usage: ${process.env.CALLER || '$0'} ${commandUsage}`)
+        yargs.usage(`Usage: ${process.env.CALLER || `$0 ${parentCommand}`} ${commandUsage}`)
         yargs.positional('collid', {
           describe: 'collection id of collection to work on',
           type: 'string'
@@ -581,7 +581,7 @@ const tasks = {
       }
     }
   },
-  jsonify: () => {
+  jsonify: (parentCommand) => {
     const commandUsage = 'jsonify <collid>'
     const handler = async argv => {
       const buildExec = path.resolve(argv.cops, 'bakery/build')
@@ -611,7 +611,7 @@ const tasks = {
       aliases: 'j',
       describe: 'build metadata from disassembled book',
       builder: yargs => {
-        yargs.usage(`Usage: ${process.env.CALLER || '$0'} ${commandUsage}`)
+        yargs.usage(`Usage: ${process.env.CALLER || `$0 ${parentCommand}`} ${commandUsage}`)
         yargs.positional('collid', {
           describe: 'collection id of collection to work on',
           type: 'string'

--- a/bakery/src/cli/execute.js
+++ b/bakery/src/cli/execute.js
@@ -63,12 +63,7 @@ const extractLocalImageDetails = imageArg => {
 const input = (dataDir, name) => `--input=${name}=${dataDir}/${name}`
 const output = (dataDir, name) => `--output=${name}=${dataDir}/${name}`
 
-const composeYml = fs.readFileSync(path.resolve(__dirname, 'docker-compose.yml'), { encoding: 'utf8' })
-
 const flyExecute = async (cmdArgs, { image, persist }) => {
-  const tmpComposeYml = tmp.fileSync()
-  fs.writeFileSync(tmpComposeYml.name, composeYml)
-
   const children = []
 
   process.on('exit', code => {
@@ -82,7 +77,7 @@ const flyExecute = async (cmdArgs, { image, persist }) => {
   })
 
   const startup = spawn('docker-compose', [
-    '-f', tmpComposeYml.name,
+    `--file=${path.resolve(__dirname, 'docker-compose.yml')}`,
     'up',
     '-d'
   ], {
@@ -175,7 +170,7 @@ const flyExecute = async (cmdArgs, { image, persist }) => {
     if (!persist) {
       console.log('cleaning up')
       const cleanUp = spawn('docker-compose', [
-        '-f', tmpComposeYml.name,
+        `--file=${COMPOSE_FILE_PATH}`,
         'stop'
       ], { stdio: 'inherit' })
       children.push(cleanUp)

--- a/bakery/src/cli/execute.js
+++ b/bakery/src/cli/execute.js
@@ -62,6 +62,7 @@ const extractLocalImageDetails = imageArg => {
 
 const input = (dataDir, name) => `--input=${name}=${dataDir}/${name}`
 const output = (dataDir, name) => `--output=${name}=${dataDir}/${name}`
+const COMPOSE_FILE_PATH = path.resolve(__dirname, 'docker-compose.yml')
 
 const flyExecute = async (cmdArgs, { image, persist }) => {
   const children = []
@@ -77,7 +78,7 @@ const flyExecute = async (cmdArgs, { image, persist }) => {
   })
 
   const startup = spawn('docker-compose', [
-    `--file=${path.resolve(__dirname, 'docker-compose.yml')}`,
+    `--file=${COMPOSE_FILE_PATH}`,
     'up',
     '-d'
   ], {
@@ -184,8 +185,8 @@ const flyExecute = async (cmdArgs, { image, persist }) => {
   }
 }
 
-const yargs = require('yargs')
-  .command((() => {
+const tasks = {
+  fetch: () => {
     const commandUsage = 'fetch <server> <collid> <version>'
     const handler = async argv => {
       const buildExec = path.resolve(argv.cops, 'bakery/build')
@@ -216,7 +217,7 @@ const yargs = require('yargs')
       aliases: 'f',
       describe: 'fetch a book',
       builder: yargs => {
-        yargs.usage(`Usage: ${process.env.CALLER || 'execute.js'} ${commandUsage}`)
+        yargs.usage(`Usage: ${process.env.CALLER || '$0'} ${commandUsage}`)
         yargs.positional('server', {
           describe: 'content server to fetch from',
           type: 'string'
@@ -232,8 +233,8 @@ const yargs = require('yargs')
         handler(argv).catch((err) => { console.error(err); process.exit(1) })
       }
     }
-  }).call())
-  .command((() => {
+  },
+  assemble: () => {
     const commandUsage = 'assemble <collid>'
     const handler = async argv => {
       const buildExec = path.resolve(argv.cops, 'bakery/build')
@@ -263,7 +264,7 @@ const yargs = require('yargs')
       aliases: 'a',
       describe: 'assemble a book',
       builder: yargs => {
-        yargs.usage(`Usage: ${process.env.CALLER || 'execute.js'} ${commandUsage}`)
+        yargs.usage(`Usage: ${process.env.CALLER || '$0'} ${commandUsage}`)
         yargs.positional('collid', {
           describe: 'collection id of collection to work on',
           type: 'string'
@@ -273,8 +274,8 @@ const yargs = require('yargs')
         handler(argv).catch((err) => { console.error(err); process.exit(1) })
       }
     }
-  }).call())
-  .command((() => {
+  },
+  bake: () => {
     const commandUsage = 'bake <collid> <recipefile> <stylefile>'
     const handler = async argv => {
       const buildExec = path.resolve(argv.cops, 'bakery/build')
@@ -313,7 +314,7 @@ const yargs = require('yargs')
       aliases: 'b',
       describe: 'bake a book',
       builder: yargs => {
-        yargs.usage(`Usage: ${process.env.CALLER || 'execute.js'} ${commandUsage}`)
+        yargs.usage(`Usage: ${process.env.CALLER || '$0'} ${commandUsage}`)
         yargs.positional('collid', {
           describe: 'collection id of collection to work on',
           type: 'string'
@@ -329,8 +330,8 @@ const yargs = require('yargs')
         handler(argv).catch((err) => { console.error(err); process.exit(1) })
       }
     }
-  }).call())
-  .command((() => {
+  },
+  mathify: () => {
     const commandUsage = 'mathify <collid>'
     const handler = async argv => {
       const buildExec = path.resolve(argv.cops, 'bakery/build')
@@ -360,7 +361,7 @@ const yargs = require('yargs')
       aliases: 'm',
       describe: 'mathify a book',
       builder: yargs => {
-        yargs.usage(`Usage: ${process.env.CALLER || 'execute.js'} ${commandUsage}`)
+        yargs.usage(`Usage: ${process.env.CALLER || '$0'} ${commandUsage}`)
         yargs.positional('collid', {
           describe: 'collection id of collection to work on',
           type: 'string'
@@ -370,8 +371,8 @@ const yargs = require('yargs')
         handler(argv).catch((err) => { console.error(err); process.exit(1) })
       }
     }
-  }).call())
-  .command((() => {
+  },
+  'build-pdf': () => {
     const commandUsage = 'build-pdf <collid>'
     const handler = async argv => {
       const buildExec = path.resolve(argv.cops, 'bakery/build')
@@ -400,7 +401,7 @@ const yargs = require('yargs')
       aliases: 'p',
       describe: 'build a pdf from a book',
       builder: yargs => {
-        yargs.usage(`Usage: ${process.env.CALLER || 'execute.js'} ${commandUsage}`)
+        yargs.usage(`Usage: ${process.env.CALLER || '$0'} ${commandUsage}`)
         yargs.positional('collid', {
           describe: 'collection id of collection to work on',
           type: 'string'
@@ -410,8 +411,8 @@ const yargs = require('yargs')
         handler(argv).catch((err) => { console.error(err); process.exit(1) })
       }
     }
-  }).call())
-  .command((() => {
+  },
+  'assemble-meta': () => {
     const commandUsage = 'assemble-meta <collid>'
     const handler = async argv => {
       const buildExec = path.resolve(argv.cops, 'bakery/build')
@@ -441,7 +442,7 @@ const yargs = require('yargs')
       aliases: 'am',
       describe: 'build metadata files from an assembled book',
       builder: yargs => {
-        yargs.usage(`Usage: ${process.env.CALLER || 'execute.js'} ${commandUsage}`)
+        yargs.usage(`Usage: ${process.env.CALLER || '$0'} ${commandUsage}`)
         yargs.positional('collid', {
           describe: 'collection id of collection to work on',
           type: 'string'
@@ -451,8 +452,8 @@ const yargs = require('yargs')
         handler(argv).catch((err) => { console.error(err); process.exit(1) })
       }
     }
-  }).call())
-  .command((() => {
+  },
+  'bake-meta': () => {
     const commandUsage = 'bake-meta <collid>'
     const handler = async argv => {
       const buildExec = path.resolve(argv.cops, 'bakery/build')
@@ -484,7 +485,7 @@ const yargs = require('yargs')
       aliases: 'bm',
       describe: 'build metadata files from a baked book',
       builder: yargs => {
-        yargs.usage(`Usage: ${process.env.CALLER || 'execute.js'} ${commandUsage}`)
+        yargs.usage(`Usage: ${process.env.CALLER || '$0'} ${commandUsage}`)
         yargs.positional('collid', {
           describe: 'collection id of collection to work on',
           type: 'string'
@@ -494,8 +495,8 @@ const yargs = require('yargs')
         handler(argv).catch((err) => { console.error(err) })
       }
     }
-  }).call())
-  .command((() => {
+  },
+  checksum: () => {
     // fly -t cops-dev execute -c checksum-book.yml -j bakery/bakery -i book=./data/book -i baked-book=./data/baked-book -o checksum-book=./data/checksum-book
     const commandUsage = 'checksum <collid>'
     const handler = async argv => {
@@ -526,7 +527,7 @@ const yargs = require('yargs')
       aliases: 'cb',
       describe: 'checksum resources from a baked book',
       builder: yargs => {
-        yargs.usage(`Usage: ${process.env.CALLER || 'execute.js'} ${commandUsage}`)
+        yargs.usage(`Usage: ${process.env.CALLER || '$0'} ${commandUsage}`)
         yargs.positional('collid', {
           describe: 'collection id of collection to work on',
           type: 'string'
@@ -536,8 +537,8 @@ const yargs = require('yargs')
         handler(argv).catch((err) => { console.error(err); process.exit(1) })
       }
     }
-  }).call())
-  .command((() => {
+  },
+  disassemble: () => {
     const commandUsage = 'disassemble <collid>'
     const handler = async argv => {
       const buildExec = path.resolve(argv.cops, 'bakery/build')
@@ -569,7 +570,7 @@ const yargs = require('yargs')
       aliases: 'd',
       describe: 'disassemble a checksummed book',
       builder: yargs => {
-        yargs.usage(`Usage: ${process.env.CALLER || 'execute.js'} ${commandUsage}`)
+        yargs.usage(`Usage: ${process.env.CALLER || '$0'} ${commandUsage}`)
         yargs.positional('collid', {
           describe: 'collection id of collection to work on',
           type: 'string'
@@ -579,8 +580,8 @@ const yargs = require('yargs')
         handler(argv).catch((err) => { console.error(err); process.exit(1) })
       }
     }
-  }).call())
-  .command((() => {
+  },
+  jsonify: () => {
     const commandUsage = 'jsonify <collid>'
     const handler = async argv => {
       const buildExec = path.resolve(argv.cops, 'bakery/build')
@@ -610,7 +611,7 @@ const yargs = require('yargs')
       aliases: 'j',
       describe: 'build metadata from disassembled book',
       builder: yargs => {
-        yargs.usage(`Usage: ${process.env.CALLER || 'execute.js'} ${commandUsage}`)
+        yargs.usage(`Usage: ${process.env.CALLER || '$0'} ${commandUsage}`)
         yargs.positional('collid', {
           describe: 'collection id of collection to work on',
           type: 'string'
@@ -620,40 +621,113 @@ const yargs = require('yargs')
         handler(argv).catch((err) => { console.error(err); process.exit(1) })
       }
     }
+  }
+}
+
+const yargs = require('yargs')
+  .command((() => {
+    const commandUsage = 'run'
+    return {
+      command: commandUsage,
+      describe: 'run a bakery task',
+      builder: yargs => {
+        yargs.usage(`Usage: ${process.env.CALLER || '$0'} ${commandUsage}`)
+        return yargs
+          .command(tasks.fetch())
+          .command(tasks.assemble())
+          .command(tasks.bake())
+          .command(tasks.mathify())
+          .command(tasks['build-pdf']())
+          .command(tasks['assemble-meta']())
+          .command(tasks.checksum())
+          .command(tasks['bake-meta']())
+          .command(tasks.disassemble())
+          .command(tasks.jsonify())
+          .option('c', {
+            alias: 'cops',
+            demandOption: true,
+            describe: 'path to output-producer-service directory',
+            normalize: true,
+            type: 'string'
+          })
+          .option('d', {
+            alias: 'data',
+            demandOption: true,
+            describe: 'path to data directory',
+            normalize: true,
+            type: 'string'
+          })
+          .option('i', {
+            alias: 'image',
+            describe: 'name of image to use instead of default',
+            type: 'string'
+          })
+          .option('t', {
+            alias: 'tag',
+            describe: 'use a particular tag of the default remote task image resource',
+            type: 'string'
+          })
+          .option('p', {
+            alias: 'persist',
+            describe: 'persist containers after running cli command',
+            boolean: true,
+            default: false
+          })
+          .conflicts('i', 't')
+      }
+    }
   }).call())
-  .option('c', {
-    alias: 'cops',
-    demandOption: true,
-    describe: 'path to output-producer-service directory',
-    normalize: true,
-    type: 'string'
-  })
-  .option('d', {
-    alias: 'data',
-    demandOption: true,
-    describe: 'path to data directory',
-    normalize: true,
-    type: 'string'
-  })
-  .option('i', {
-    alias: 'image',
-    describe: 'name of image to use instead of default',
-    type: 'string'
-  })
-  .option('t', {
-    alias: 'tag',
-    describe: 'use a particular tag of the default remote task image resource',
-    type: 'string'
-  })
-  .option('p', {
-    alias: 'persist',
-    describe: 'persist containers after running cli command',
-    boolean: true,
-    default: false
-  })
-  .conflicts('i', 't')
+  .command((() => {
+    const commandUsage = 'up'
+    const handler = async _ => {
+      const teardown = spawn('docker-compose', [
+        `--file=${COMPOSE_FILE_PATH}`,
+        'up',
+        '-d'
+      ], { stdio: 'inherit' })
+      await completion(teardown)
+    }
+    return {
+      command: commandUsage,
+      describe: 'start up bakery-cli spawned containers',
+      builder: yargs => {
+        yargs.usage(`Usage: ${process.env.CALLER || '$0'} ${commandUsage}`)
+      },
+      handler: argv => {
+        handler(argv).catch((err) => { console.error(err); process.exit(1) })
+      }
+    }
+  }).call())
+  .command((() => {
+    const commandUsage = 'stop'
+    const handler = async argv => {
+      const composeCmd = argv.destroy ? 'down' : 'stop'
+      const teardown = spawn('docker-compose', [
+        `--file=${COMPOSE_FILE_PATH}`,
+        composeCmd
+      ], { stdio: 'inherit' })
+      await completion(teardown)
+    }
+    return {
+      command: commandUsage,
+      describe: 'clean up bakery-cli spawned containers',
+      builder: yargs => {
+        yargs.usage(`Usage: ${process.env.CALLER || '$0'} ${commandUsage}`)
+        yargs.option('d', {
+          alias: 'destroy',
+          describe: 'destroy containers as well',
+          boolean: true,
+          default: false
+        })
+      },
+      handler: argv => {
+        handler(argv).catch((err) => { console.error(err); process.exit(1) })
+      }
+    }
+  }).call())
   .demandCommand(1, 'command required')
   .help()
+  .alias('h', 'help')
   .wrap(process.env.COLUMNS)
   .version(false)
   .strict()

--- a/bakery/src/cli/execute.js
+++ b/bakery/src/cli/execute.js
@@ -497,7 +497,6 @@ const tasks = {
     }
   },
   checksum: (parentCommand) => {
-    // fly -t cops-dev execute -c checksum-book.yml -j bakery/bakery -i book=./data/book -i baked-book=./data/baked-book -o checksum-book=./data/checksum-book
     const commandUsage = 'checksum <collid>'
     const handler = async argv => {
       const buildExec = path.resolve(argv.cops, 'bakery/build')

--- a/bakery/src/tests/test_cli.js
+++ b/bakery/src/tests/test_cli.js
@@ -107,6 +107,7 @@ test('stable flow in pdf and distribution pipeline', async t => {
   await fs.copy(`${dataDir}/${bookId}`, `${outputDir}/${bookId}`)
 
   const commonArgs = [
+    'run',
     '--cops=..',
     `--data=${outputDir}`,
     '--persist'
@@ -164,22 +165,12 @@ test('stable flow in pdf and distribution pipeline', async t => {
     bookId
   ])
 
+  // Distribution
   const checksum = spawn('node', [
     'src/cli/execute.js',
     ...commonArgs,
     '--image=localhost:5000/openstax/cops-bakery-scripts:test',
     'checksum',
-    bookId
-  ])
-  await completion(checksum)
-  t.truthy(fs.existsSync(`${outputDir}/${bookId}/checksum-book/${bookId}/resources`))
-
-  // Distribution
-  const bakeMeta = spawn('node', [
-    'src/cli/execute.js',
-    ...commonArgs,
-    '--image=localhost:5000/openstax/cops-bakery-scripts:test',
-    'bake-meta',
     bookId
   ])
 
@@ -200,8 +191,18 @@ test('stable flow in pdf and distribution pipeline', async t => {
   })
 
   // Distribution continued
-  const branchDistribution = completion(bakeMeta).then(async (bakeMetaResult) => {
-    // bake-meta assertion
+  const branchDistribution = completion(checksum).then(async (checksumResult) => {
+    // checksum assertion
+    t.truthy(fs.existsSync(`${outputDir}/${bookId}/checksum-book/${bookId}/resources`), formatSubprocessOutput(checksumResult))
+
+    const bakeMeta = spawn('node', [
+      'src/cli/execute.js',
+      ...commonArgs,
+      '--image=localhost:5000/openstax/cops-bakery-scripts:test',
+      'bake-meta',
+      bookId
+    ])
+    const bakeMetaResult = await completion(bakeMeta)
     t.truthy(fs.existsSync(`${outputDir}/${bookId}/baked-book-metadata/${bookId}/collection.baked-metadata.json`), formatSubprocessOutput(bakeMetaResult))
 
     const disassemble = spawn('node', [


### PR DESCRIPTION
`stop` will help clean up any containers that are left running for whatever reason, and there is a `-d` option to destroy the containers. `up` will start the containers again, but is probably only useful for debugging purposes.

Because the requirements for these kinds of commands are very different, task commands have been scoped under the `run` subcommand. E.g. `fetch` -> `run fetch`. Documentation has been changed to reflect this.

The restructuring should also help prepare for removal of the `-c` flag and packaging for npm.