### PR TITLE
Add code version to upload bucket prefix

### DIFF
--- a/bakery/src/tasks/upload-book.js
+++ b/bakery/src/tasks/upload-book.js
@@ -9,7 +9,8 @@ const task = (taskArgs) => {
   }
   const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
   const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })
-  const bucketPrefix = 'apps/archive'
+  const codeVersionFromTag = imageSource.tag || 'version-unknown'
+  const bucketPrefix = `apps/archive/${codeVersionFromTag}`
 
   return {
     task: 'upload book',


### PR DESCRIPTION
Should be enough to satisfy our needs. If no tag given (which represents our code version), sets version to 'version-unknown'.
A tag/code-version like `dev` might slip through, but I can't think of a good way to tell whether or not the tag given will be an immutable one or mutable one (because it's entirely convention based).