### PR TITLE
Use master tag for images by default

### DIFF
--- a/bakery/src/cli/execute.js
+++ b/bakery/src/cli/execute.js
@@ -28,7 +28,7 @@ const stripLocalPrefix = imageArg => {
 }
 
 const imageDetailsFromArgs = (argv) => {
-  let imageDetails = null
+  let imageDetails = {}
   if (argv.image) {
     imageDetails = extractLocalImageDetails(argv.image)
   }
@@ -36,7 +36,7 @@ const imageDetailsFromArgs = (argv) => {
     imageDetails = { tag: argv.tag }
   }
   console.log(`extracted image details: ${JSON.stringify(imageDetails)}`)
-  return imageDetails == null ? null : { image: imageDetails }
+  return { image: imageDetails }
 }
 
 const extractLocalImageDetails = imageArg => {
@@ -48,15 +48,15 @@ const extractLocalImageDetails = imageArg => {
   let imageName, imageTag
   if (tagNameSeparatorIndex === -1) {
     imageName = imageArgStripped
-    imageTag = 'latest'
   } else {
     imageName = imageArgStripped.slice(0, tagNameSeparatorIndex)
     imageTag = imageArgStripped.slice(tagNameSeparatorIndex + 1)
   }
+  const maybeTag = imageTag == null ? {} : { tag: imageTag }
   const details = {
     registry: 'registry:5000',
     name: imageName,
-    tag: imageTag
+    ...maybeTag
   }
   return details
 }

--- a/bakery/src/pipelines/distribution.js
+++ b/bakery/src/pipelines/distribution.js
@@ -13,13 +13,15 @@ const pipeline = (env) => {
   const awsAccessKeyId = env.ENV_NAME === 'local' ? env.S3_ACCESS_KEY_ID : '((aws-sandbox-secret-key-id))'
   const awsSecretAccessKey = env.ENV_NAME === 'local' ? env.S3_SECRET_ACCESS_KEY : '((aws-sandbox-secret-access-key))'
 
+  const lockedTag = env.IMAGE_TAG || 'master'
+
   const resources = [
     {
       name: 'cnx-recipes-output',
       type: 'docker-image',
       source: {
         repository: 'openstax/cnx-recipes-output',
-        tag: env.IMAGE_TAG || 'latest'
+        tag: lockedTag
       }
     },
     {
@@ -41,21 +43,21 @@ const pipeline = (env) => {
       { get: 'cnx-recipes-output' },
       taskLookUpFeed({
         versionedFile: env.VERSIONED_FILE,
-        image: { tag: env.IMAGE_TAG }
+        image: { tag: lockedTag }
       }),
-      taskFetchBook({ image: { tag: env.IMAGE_TAG } }),
-      taskAssembleBook({ image: { tag: env.IMAGE_TAG } }),
-      taskAssembleBookMeta({ image: { tag: env.IMAGE_TAG } }),
-      taskBakeBook({ image: { tag: env.IMAGE_TAG } }),
-      taskBakeBookMeta({ image: { tag: env.IMAGE_TAG } }),
-      taskChecksumBook({ image: { tag: env.IMAGE_TAG } }),
-      taskDisassembleBook({ image: { tag: env.IMAGE_TAG } }),
-      taskJsonifyBook({ image: { tag: env.IMAGE_TAG } }),
+      taskFetchBook({ image: { tag: lockedTag } }),
+      taskAssembleBook({ image: { tag: lockedTag } }),
+      taskAssembleBookMeta({ image: { tag: lockedTag } }),
+      taskBakeBook({ image: { tag: lockedTag } }),
+      taskBakeBookMeta({ image: { tag: lockedTag } }),
+      taskChecksumBook({ image: { tag: lockedTag } }),
+      taskDisassembleBook({ image: { tag: lockedTag } }),
+      taskJsonifyBook({ image: { tag: lockedTag } }),
       taskUploadBook({
         bucketName: env.S3_DIST_BUCKET,
         awsAccessKeyId: awsAccessKeyId,
         awsSecretAccessKey: awsSecretAccessKey,
-        image: { tag: env.IMAGE_TAG }
+        image: { tag: lockedTag }
       })
     ]
   }

--- a/bakery/src/pipelines/pdf.js
+++ b/bakery/src/pipelines/pdf.js
@@ -6,6 +6,8 @@ const pipeline = (env) => {
   const taskMathifyBook = require('../tasks/mathify-book')
   const taskBuildPdf = require('../tasks/build-pdf')
 
+  const lockedTag = env.IMAGE_TAG || 'master'
+
   // FIXME: This mapping should be in the COPS resource
   const Status = Object.freeze({
     QUEUED: 1,
@@ -32,7 +34,7 @@ const pipeline = (env) => {
       type: 'docker-image',
       source: {
         repository: 'openstax/output-producer-resource',
-        tag: env.IMAGE_TAG || 'latest'
+        tag: lockedTag
       }
     }
   ]
@@ -43,7 +45,7 @@ const pipeline = (env) => {
       type: 'docker-image',
       source: {
         repository: 'openstax/cnx-recipes-output',
-        tag: env.IMAGE_TAG || 'latest'
+        tag: lockedTag
       }
     },
     {
@@ -76,13 +78,13 @@ const pipeline = (env) => {
       { get: 'output-producer', trigger: true, version: 'every' },
       reportToOutputProducer(Status.ASSIGNED),
       { get: 'cnx-recipes-output' },
-      taskLookUpBook({ image: { tag: env.IMAGE_TAG } }),
+      taskLookUpBook({ image: { tag: lockedTag } }),
       reportToOutputProducer(Status.PROCESSING),
-      taskFetchBook({ image: { tag: env.IMAGE_TAG } }),
-      taskAssembleBook({ image: { tag: env.IMAGE_TAG } }),
-      taskBakeBook({ image: { tag: env.IMAGE_TAG } }),
-      taskMathifyBook({ image: { tag: env.IMAGE_TAG } }),
-      taskBuildPdf({ bucketName: env.S3_PDF_BUCKET, image: { tag: env.IMAGE_TAG } }),
+      taskFetchBook({ image: { tag: lockedTag } }),
+      taskAssembleBook({ image: { tag: lockedTag } }),
+      taskBakeBook({ image: { tag: lockedTag } }),
+      taskMathifyBook({ image: { tag: lockedTag } }),
+      taskBuildPdf({ bucketName: env.S3_PDF_BUCKET, image: { tag: lockedTag } }),
       {
         put: 's3',
         params: {

--- a/bakery/src/tasks/assemble-book-metadata.js
+++ b/bakery/src/tasks/assemble-book-metadata.js
@@ -4,7 +4,8 @@ const { constructImageSource } = require('../task-util/task-util')
 
 const task = (taskArgs) => {
   const imageDefault = {
-    name: 'openstax/cops-bakery-scripts'
+    name: 'openstax/cops-bakery-scripts',
+    tag: 'master'
   }
   const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
   const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })

--- a/bakery/src/tasks/assemble-book.js
+++ b/bakery/src/tasks/assemble-book.js
@@ -4,7 +4,8 @@ const { constructImageSource } = require('../task-util/task-util')
 
 const task = (taskArgs) => {
   const imageDefault = {
-    name: 'openstax/nebuchadnezzar'
+    name: 'openstax/nebuchadnezzar',
+    tag: 'master'
   }
   const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
   const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })

--- a/bakery/src/tasks/bake-book-metadata.js
+++ b/bakery/src/tasks/bake-book-metadata.js
@@ -4,7 +4,8 @@ const { constructImageSource } = require('../task-util/task-util')
 
 const task = (taskArgs) => {
   const imageDefault = {
-    name: 'openstax/cops-bakery-scripts'
+    name: 'openstax/cops-bakery-scripts',
+    tag: 'master'
   }
   const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
   const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })

--- a/bakery/src/tasks/bake-book.js
+++ b/bakery/src/tasks/bake-book.js
@@ -4,7 +4,8 @@ const { constructImageSource } = require('../task-util/task-util')
 
 const task = (taskArgs) => {
   const imageDefault = {
-    name: 'openstax/cnx-easybake'
+    name: 'openstax/cnx-easybake',
+    tag: 'master'
   }
   const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
   const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })

--- a/bakery/src/tasks/build-pdf.js
+++ b/bakery/src/tasks/build-pdf.js
@@ -5,7 +5,8 @@ const { constructImageSource } = require('../task-util/task-util')
 const task = (taskArgs) => {
   const { bucketName } = taskArgs
   const imageDefault = {
-    name: 'openstax/princexml'
+    name: 'openstax/princexml',
+    tag: 'master'
   }
   const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
   const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })

--- a/bakery/src/tasks/check-feed.js
+++ b/bakery/src/tasks/check-feed.js
@@ -5,7 +5,8 @@ const { constructImageSource } = require('../task-util/task-util')
 const task = (taskArgs) => {
   const { awsAccessKeyId, awsSecretAccessKey, bucketName, feedFileUrl } = taskArgs
   const imageDefault = {
-    name: 'openstax/cops-bakery-scripts'
+    name: 'openstax/cops-bakery-scripts',
+    tag: 'master'
   }
   const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
   const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })

--- a/bakery/src/tasks/checksum-book.js
+++ b/bakery/src/tasks/checksum-book.js
@@ -4,7 +4,8 @@ const { constructImageSource } = require('../task-util/task-util')
 
 const task = (taskArgs) => {
   const imageDefault = {
-    name: 'openstax/cops-bakery-scripts'
+    name: 'openstax/cops-bakery-scripts',
+    tag: 'master'
   }
   const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
   const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })

--- a/bakery/src/tasks/disassemble-book.js
+++ b/bakery/src/tasks/disassemble-book.js
@@ -4,7 +4,8 @@ const { constructImageSource } = require('../task-util/task-util')
 
 const task = (taskArgs) => {
   const imageDefault = {
-    name: 'openstax/cops-bakery-scripts'
+    name: 'openstax/cops-bakery-scripts',
+    tag: 'master'
   }
   const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
   const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })

--- a/bakery/src/tasks/fetch-book.js
+++ b/bakery/src/tasks/fetch-book.js
@@ -4,7 +4,8 @@ const { constructImageSource } = require('../task-util/task-util')
 
 const task = (taskArgs) => {
   const imageDefault = {
-    name: 'openstax/nebuchadnezzar'
+    name: 'openstax/nebuchadnezzar',
+    tag: 'master'
   }
   const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
   const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })

--- a/bakery/src/tasks/jsonify-book.js
+++ b/bakery/src/tasks/jsonify-book.js
@@ -4,7 +4,8 @@ const { constructImageSource } = require('../task-util/task-util')
 
 const task = (taskArgs) => {
   const imageDefault = {
-    name: 'openstax/cops-bakery-scripts'
+    name: 'openstax/cops-bakery-scripts',
+    tag: 'master'
   }
   const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
   const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })

--- a/bakery/src/tasks/look-up-book.js
+++ b/bakery/src/tasks/look-up-book.js
@@ -4,7 +4,8 @@ const { constructImageSource } = require('../task-util/task-util')
 
 const task = (taskArgs) => {
   const imageDefault = {
-    name: 'openstax/nebuchadnezzar'
+    name: 'openstax/nebuchadnezzar',
+    tag: 'master'
   }
   const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
   const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })

--- a/bakery/src/tasks/look-up-feed.js
+++ b/bakery/src/tasks/look-up-feed.js
@@ -5,7 +5,8 @@ const { constructImageSource } = require('../task-util/task-util')
 const task = (taskArgs) => {
   const { versionedFile } = taskArgs
   const imageDefault = {
-    name: 'openstax/cops-bakery-scripts'
+    name: 'openstax/cops-bakery-scripts',
+    tag: 'master'
   }
   const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
   const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })

--- a/bakery/src/tasks/mathify-book.js
+++ b/bakery/src/tasks/mathify-book.js
@@ -4,7 +4,8 @@ const { constructImageSource } = require('../task-util/task-util')
 
 const task = (taskArgs) => {
   const imageDefault = {
-    name: 'openstax/mathify'
+    name: 'openstax/mathify',
+    tag: 'master'
   }
   const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
   const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })

--- a/bakery/src/tasks/upload-book.js
+++ b/bakery/src/tasks/upload-book.js
@@ -5,7 +5,8 @@ const { constructImageSource } = require('../task-util/task-util')
 const task = (taskArgs) => {
   const { awsAccessKeyId, awsSecretAccessKey, bucketName } = taskArgs
   const imageDefault = {
-    name: 'openstax/cops-bakery-scripts'
+    name: 'openstax/cops-bakery-scripts',
+    tag: 'master'
   }
   const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
   const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })


### PR DESCRIPTION
We've recently transitioned to updating the `master` tag for all our images upon push to master branches (and not updating latest). This will ensure CLI users will not be running old code or pinned code unless they mean to.