### PR TITLE
Fix undefined word in help messages

### DIFF
--- a/bakery/src/cli/execute.js
+++ b/bakery/src/cli/execute.js
@@ -680,16 +680,16 @@ const yargs = require('yargs')
       builder: yargs => {
         yargs.usage(`Usage: ${process.env.CALLER || '$0'} ${commandUsage}`)
         return yargs
-          .command(tasks.fetch())
-          .command(tasks.assemble())
-          .command(tasks.bake())
-          .command(tasks.mathify())
-          .command(tasks['build-pdf']())
-          .command(tasks['assemble-meta']())
-          .command(tasks.checksum())
-          .command(tasks['bake-meta']())
-          .command(tasks.disassemble())
-          .command(tasks.jsonify())
+          .command(tasks.fetch(commandUsage))
+          .command(tasks.assemble(commandUsage))
+          .command(tasks.bake(commandUsage))
+          .command(tasks.mathify(commandUsage))
+          .command(tasks['build-pdf'](commandUsage))
+          .command(tasks['assemble-meta'](commandUsage))
+          .command(tasks.checksum(commandUsage))
+          .command(tasks['bake-meta'](commandUsage))
+          .command(tasks.disassemble(commandUsage))
+          .command(tasks.jsonify(commandUsage))
           .option('d', {
             alias: 'data',
             demandOption: true,


### PR DESCRIPTION
Purely cosmetic.
Before:
![run-undefined-before](https://user-images.githubusercontent.com/1285308/84949715-4581f200-b0b3-11ea-886d-93d42b3ce8ec.png)
After:
![run-undefined-after](https://user-images.githubusercontent.com/1285308/84949725-4a46a600-b0b3-11ea-89a3-d380796d3a94.png)
