### PR TITLE
Remove broken-link validation in validate-xhtml

### DIFF
--- a/bakery/src/tasks/validate-xhtml.js
+++ b/bakery/src/tasks/validate-xhtml.js
@@ -32,7 +32,6 @@ const task = (taskArgs) => {
           for xhtmlfile in "${inputSource}/$collection_id/"${inputPath}
           do
             java -cp /xhtml-validator.jar org.openstax.xml.Main "$xhtmlfile" link-to-duplicate-id
-            java -cp /xhtml-validator.jar org.openstax.xml.Main "$xhtmlfile" broken-link
           done
         `
         ]


### PR DESCRIPTION
We included the broken-link validation to start with to see how many
books might pass / fail with it incorporated. In our initial approved
books list, we found 15 out of 44 books failed the validation
including:

- Elementary Algebra 2e
- Precalculus
- Microbiology
- Principles of Management
- Principles of Economics 2e
- Introductory Business Statistics
- College Algebra
- Principles of Macroeconomics for AP® Courses 2e
- College Physics for AP® Courses
- Principles of Microeconomics for AP® Courses 2e
- Principles of Microeconomics 2e
- Introductory Statistics
- Organizational Behavior
- Principles of Macroeconomics 2e
- Algebra and Trigonometry

Based upon these results, we'll remove this validation for the time
being.