### PR TITLE
fix canonical-book-list.json

### DIFF
--- a/bakery/src/scripts/canonical-book-list.json
+++ b/bakery/src/scripts/canonical-book-list.json
@@ -42,7 +42,7 @@
         },
         {
             "uuid": "7fccc9cf-9b71-44f6-800b-f9457fd64335",
-            "_name": "Chemistry 2e "
+            "_name": "Chemistry 2e"
         },
         {
             "uuid": "8b89d172-2927-466f-8661-01abc7ccdba4",


### PR DESCRIPTION
remove space from "Chemistry 2e "