### PR TITLE
Add pending + retry states for feeder job

### DIFF
--- a/bakery/src/scripts/check-feed.py
+++ b/bakery/src/scripts/check-feed.py
@@ -1,6 +1,7 @@
 import sys
 import json
 from pathlib import Path
+from datetime import datetime
 import boto3
 import botocore
 
@@ -19,35 +20,65 @@ def main():
 
     # Iterate through feed and check for a book that is not completed based
     # upon the existence of a {code_version}/.{collection_id}@{version}.complete
-    # file in S3 bucket
+    # file in S3 bucket. If the book is not complete, check pending and retry
+    # states to see whether or not it has errored or timed out too many times
+    # to be queued again.
     for book in feed_data:
         # Check for loop exit condition
         if books_queued >= max_books_per_run:
             break
 
-        complete_filename = \
-            f".{book['collection_id']}@{book['version']}.complete"
-        bucket_key = f"{code_version}/{complete_filename}"
+        book_prefix = f".{book['collection_id']}@{book['version']}"
 
+        complete_filename = f"{book_prefix}.complete"
+        complete_key = f"{code_version}/{complete_filename}"
         try:
-            print(f"Checking for s3://{queue_state_bucket}/{bucket_key}")
+            print(f"Checking for s3://{queue_state_bucket}/{complete_key}")
             s3_client.head_object(
                 Bucket=queue_state_bucket,
-                Key=bucket_key
+                Key=complete_key
             )
+            # Book is complete, move along to next book
+            continue
         except botocore.exceptions.ClientError as error:
             error_code = error.response['Error']['Code']
-            if error_code == '404':
-                print(f"Found feed entry to build: {book}")
-                s3_client.put_object(
-                    Bucket=queue_state_bucket,
-                    Key=queue_filename,
-                    Body=json.dumps(book)
-                )
-                books_queued += 1
-            else:
+            if error_code != '404':
                 # Not an expected 404 error
                 raise
+            # Otherwise, book is not complete and we check other states
+
+        # These states are order-dependant.
+        # i.e. only move to retry if pending passes through
+        for state in ['pending', 'retry']:
+            state_filename = f"{book_prefix}.{state}"
+            state_key = f"{code_version}/{state_filename}"
+            try:
+                print(f"Checking for s3://{queue_state_bucket}/{state_key}")
+                s3_client.head_object(
+                    Bucket=queue_state_bucket,
+                    Key=state_key
+                )
+            except botocore.exceptions.ClientError as error:
+                error_code = error.response['Error']['Code']
+                if error_code == '404':
+                    print(f"Found feed entry to build: {book}")
+                    s3_client.put_object(
+                        Bucket=queue_state_bucket,
+                        Key=queue_filename,
+                        Body=json.dumps(book)
+                    )
+                    # Mark state to not be entered again
+                    s3_client.put_object(
+                        Bucket=queue_state_bucket,
+                        Key=state_key,
+                        Body=datetime.now().astimezone().isoformat(timespec='seconds')
+                    )
+                    books_queued += 1
+                    # Book was queued, don't try to queue it again
+                    break
+                else:
+                    # Not an expected 404 error
+                    raise
 
     print(f"Queued {books_queued} books")
 


### PR DESCRIPTION
Adds `.pending` and `.retry` files in the queue_state bucket. Seems to work as intended. As you can see on the [concourse pipeline ](https://concourse-v6.openstax.org/teams/CE/pipelines/webhost-staging-tomjw64-dev)and the [s3 bucket](https://s3.console.aws.amazon.com/s3/buckets/sandbox-web-hosting-content-queue-state/20200721.153415/?region=us-east-1&tab=overview), file generate as expected. I actually got lucky and build 4 encountered a network error and retried successfully on build 8, so we got to see both the happy and unhappy paths (builds 2,3 I changed to intentionally always fail and their retries were builds 6,7)