### PR TITLE
Re-enable duplicate id validation

### DIFF
--- a/bakery/src/cli/execute.js
+++ b/bakery/src/cli/execute.js
@@ -672,13 +672,13 @@ const tasks = {
     }
   },
   'validate-xhtml': (parentCommand) => {
-    const commandUsage = 'validate-xhtml <collid> <inputsource> <inputpath>'
+    const commandUsage = 'validate-xhtml <collid> <inputsource> <inputpath> <validationname>'
     const handler = async argv => {
       const buildExec = path.resolve(BAKERY_PATH, 'build')
 
       const imageDetails = imageDetailsFromArgs(argv)
       const taskArgs = [`--taskargs=${JSON.stringify(
-        { ...imageDetails, ...{ inputSource: argv.inputsource, inputPath: argv.inputpath } }
+        { ...imageDetails, ...{ inputSource: argv.inputsource, inputPath: argv.inputpath, validationName: argv.validationname } }
       )}`]
       const taskContent = execFileSync(buildExec, ['task', 'validate-xhtml', ...taskArgs])
       const tmpTaskFile = tmp.fileSync()

--- a/bakery/src/pipelines/distribution.js
+++ b/bakery/src/pipelines/distribution.js
@@ -86,7 +86,8 @@ const pipeline = (env) => {
       taskValidateXhtml({
         image: { tag: lockedTag },
         inputSource: 'jsonified-book',
-        inputPath: 'jsonified/*@*.xhtml'
+        inputPath: 'jsonified/*@*.xhtml',
+        validationName: 'duplicate-id'
       }),
       taskUploadBook({
         distBucket: env.S3_DIST_BUCKET,

--- a/bakery/src/pipelines/pdf.js
+++ b/bakery/src/pipelines/pdf.js
@@ -88,7 +88,8 @@ const pipeline = (env) => {
       taskValidateXhtml({
         image: { tag: lockedTag },
         inputSource: 'mathified-book',
-        inputPath: 'collection.mathified.xhtml'
+        inputPath: 'collection.mathified.xhtml',
+        validationName: 'link-to-duplicate-id'
       }),
       taskBuildPdf({ bucketName: env.S3_PDF_BUCKET, image: { tag: lockedTag } }),
       {

--- a/bakery/src/tasks/validate-xhtml.js
+++ b/bakery/src/tasks/validate-xhtml.js
@@ -3,7 +3,7 @@ const dedent = require('dedent')
 const { constructImageSource } = require('../task-util/task-util')
 
 const task = (taskArgs) => {
-  const { inputSource, inputPath } = taskArgs
+  const { inputSource, inputPath, validationName } = taskArgs
   const imageDefault = {
     name: 'openstax/xhtml-validator',
     tag: 'trunk'
@@ -31,7 +31,7 @@ const task = (taskArgs) => {
           collection_id="$(cat book/collection_id)"
           for xhtmlfile in "${inputSource}/$collection_id/"${inputPath}
           do
-            java -cp /xhtml-validator.jar org.openstax.xml.Main "$xhtmlfile" duplicate-id
+            java -cp /xhtml-validator.jar org.openstax.xml.Main "$xhtmlfile" ${validationName}
           done
         `
         ]

--- a/bakery/src/tasks/validate-xhtml.js
+++ b/bakery/src/tasks/validate-xhtml.js
@@ -31,7 +31,7 @@ const task = (taskArgs) => {
           collection_id="$(cat book/collection_id)"
           for xhtmlfile in "${inputSource}/$collection_id/"${inputPath}
           do
-            java -cp /xhtml-validator.jar org.openstax.xml.Main "$xhtmlfile" link-to-duplicate-id
+            java -cp /xhtml-validator.jar org.openstax.xml.Main "$xhtmlfile" duplicate-id
           done
         `
         ]

--- a/bakery/src/tests/test_cli.js
+++ b/bakery/src/tests/test_cli.js
@@ -160,7 +160,8 @@ test('stable flow in pdf and distribution pipeline', async t => {
     'validate-xhtml',
     bookId,
     'assembled-book',
-    'collection.assembled.xhtml'
+    'collection.assembled.xhtml',
+    'link-to-duplicate-id'
   ])
   await completion(assembleValidateXhtml)
 
@@ -191,7 +192,8 @@ test('stable flow in pdf and distribution pipeline', async t => {
     'validate-xhtml',
     bookId,
     'baked-book',
-    'collection.baked.xhtml'
+    'collection.baked.xhtml',
+    'link-to-duplicate-id'
   ])
   await completion(bakeValidateXhtml)
 
@@ -223,7 +225,8 @@ test('stable flow in pdf and distribution pipeline', async t => {
       'validate-xhtml',
       bookId,
       'mathified-book',
-      'collection.mathified.xhtml'
+      'collection.mathified.xhtml',
+      'link-to-duplicate-id'
     ])
     await completion(mathifyValidateXhtml)
 
@@ -249,7 +252,8 @@ test('stable flow in pdf and distribution pipeline', async t => {
       'validate-xhtml',
       bookId,
       'checksum-book',
-      'collection.baked.xhtml'
+      'collection.baked.xhtml',
+      'link-to-duplicate-id'
     ])
     await completion(checksumValidateXhtml)
 
@@ -279,7 +283,8 @@ test('stable flow in pdf and distribution pipeline', async t => {
       'validate-xhtml',
       bookId,
       'disassembled-book',
-      'disassembled/*@*.xhtml'
+      'disassembled/*@*.xhtml',
+      'duplicate-id'
     ])
     await completion(disassembleValidateXhtml)
 
@@ -299,7 +304,8 @@ test('stable flow in pdf and distribution pipeline', async t => {
       'validate-xhtml',
       bookId,
       'jsonified-book',
-      'jsonified/*@*.xhtml'
+      'jsonified/*@*.xhtml',
+      'duplicate-id'
     ])
     await completion(jsonifyValidateXhtml)
   })


### PR DESCRIPTION
Switches out the links-to-duplicate-id for the duplicate-id validation (if there are no duplicate ids, there can be no links to duplicate ids!) My hunch is that with the new version of cnx-epub, this should pass in most cases now. (But I could be wrong, in which case, we should revert it again)