### PR TITLE
Remove credentials from local.json env settings

### DIFF
--- a/bakery/env/local.json
+++ b/bakery/env/local.json
@@ -2,8 +2,6 @@
   "ENV_NAME": "local",
   "COPS_TARGET": "http://backend/api",
   "S3_PDF_BUCKET": "my-bucket",
-  "S3_ACCESS_KEY_ID": "",
-  "S3_SECRET_ACCESS_KEY": "",
   "S3_DIST_BUCKET": "",
   "S3_QUEUE_STATE_BUCKET": "",
   "QUEUE_FILENAME": "",

--- a/docs/operations/generate_pipeline_config.rst
+++ b/docs/operations/generate_pipeline_config.rst
@@ -20,9 +20,9 @@ Prerequisites
 
 3. Install Concourse fly cli
 ============================
-  
+
 - For Linux, `Download the cli command binary <https://concourse-ci.org/quick-start.html>`_
-- For Mac, Install with ``brew cask install fly``.  
+- For Mac, Install with ``brew cask install fly``.
 
 [There is better way to do this with CLI now]
 
@@ -31,6 +31,13 @@ Prerequisites
 ***************************
 Generate Configuration File
 ***************************
+
+When running locally, you need to set appropriate AWS credentials in your environment if you don't have them set already:
+
+.. code-block:: bash
+
+    $ export AWS_ACCESS_KEY_ID="VALUE"
+    $ export AWS_SECRET_ACCESS_KEY="VALUE"
 
 Generate pipeline configuration file with output flag ``-o``. If no output file is given it will stdout.
 


### PR DESCRIPTION
In order to avoid the risk of committing secrets, when building a
pipeline for local environments we'll grab the AWS credentials using
the corresponding environment variables typically used for AWS CLI.