### PR TITLE
Improve bakery scripts unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,12 @@ jobs:
       - run:
           name: Run bakery scripts tests
           command: |
-            pytest bakery -vvv --junitxml=/tmp/test-reports/junit.xml
+            pytest --cov=bakery_scripts --cov-report=html --cov-report=term bakery -vvv --junitxml=/tmp/test-reports/junit.xml
+
+      - run:
+          name: Upload code coverage results
+          command: |
+            bash <(curl -s https://codecov.io/bash)
 
       - store_artifacts:
           path: /tmp/test-reports/junit.xml

--- a/bakery/src/scripts/bake_book_metadata.py
+++ b/bakery/src/scripts/bake_book_metadata.py
@@ -1,6 +1,6 @@
 import sys
 import json
-from scripts import utils
+from . import utils
 
 from lxml import etree
 from cnxepub.html_parsers import DocumentMetadataParser

--- a/bakery/src/scripts/disassemble_book.py
+++ b/bakery/src/scripts/disassemble_book.py
@@ -1,6 +1,6 @@
 import sys
 import json
-from scripts import utils
+from . import utils
 from pathlib import Path
 from datetime import datetime
 

--- a/bakery/src/scripts/setup.py
+++ b/bakery/src/scripts/setup.py
@@ -29,7 +29,7 @@ SETUP_KWARGS = dict(
     install_requires=install_requires,
     tests_require=tests_require,
     extras_require=extras_require,
-    packages=['scripts'],
+    packages=['bakery_scripts'],
     include_package_data=True,
 )
 
@@ -41,17 +41,17 @@ setup(
     author='OpenStax Content Engineering',
     url="https://github.com/openstax/output-producer-service",
     license='AGPLv3.0',
-    package_dir={"scripts": "."},
+    package_dir={"bakery_scripts": "."},
     entry_points={
         'console_scripts': [
-            'assemble-meta = scripts.assemble_book_metadata:main',
-            'link-extras = scripts.link_extras:main',
-            'bake-meta = scripts.bake_book_metadata:main',
-            'disassemble = scripts.disassemble_book:main',
-            'checksum = scripts.checksum_resource:main',
-            'jsonify = scripts.jsonify_book:main',
-            'check-feed = scripts.check_feed:main',
-            'copy-resources-s3 = scripts.copy_resources_s3:main'
+            'assemble-meta = bakery_scripts.assemble_book_metadata:main',
+            'link-extras = bakery_scripts.link_extras:main',
+            'bake-meta = bakery_scripts.bake_book_metadata:main',
+            'disassemble = bakery_scripts.disassemble_book:main',
+            'checksum = bakery_scripts.checksum_resource:main',
+            'jsonify = bakery_scripts.jsonify_book:main',
+            'check-feed = bakery_scripts.check_feed:main',
+            'copy-resources-s3 = bakery_scripts.copy_resources_s3:main'
         ]
     },
     **SETUP_KWARGS,

--- a/bakery/src/scripts/setup.py
+++ b/bakery/src/scripts/setup.py
@@ -19,6 +19,7 @@ install_requires = parse_requirements(os.path.join(HERE, 'requirements.txt'))
 tests_require = [
     'pytest',
     'pytest-mock',
+    'pytest-cov',
     'flake8'
 ]
 extras_require = {

--- a/bakery/src/scripts/setup.py
+++ b/bakery/src/scripts/setup.py
@@ -18,6 +18,7 @@ def parse_requirements(req_file):
 install_requires = parse_requirements(os.path.join(HERE, 'requirements.txt'))
 tests_require = [
     'pytest',
+    'pytest-mock',
     'flake8'
 ]
 extras_require = {

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+  - .*bakery_scripts::bakery/src/scripts/


### PR DESCRIPTION
These changes incorporate a few improvements:
* Removing use of `subprocess` in lieu of importing script functions
* Adding code coverage reporting
* Adding test for coverage on `check_feed` script
