### PR TITLE
Work around boto stubber request order enforcement

### DIFF
--- a/bakery/src/tests/test_bakery_scripts.py
+++ b/bakery/src/tests/test_bakery_scripts.py
@@ -1141,6 +1141,20 @@ def test_gdocify_book(tmp_path, mocker):
         assert expected_links_by_id[node.attrib["id"]] == node.attrib["href"]
 
 
+class ANY_OF:
+    def __init__(self, items):
+        self.items = items
+
+    def __eq__(self, other):
+        return other in self.items
+
+    def __ne__(self, other):
+        return other not in self.items
+
+    def __repr__(self):
+        return f'<ANY OF {self.items}>'
+
+
 def test_copy_resource_s3(tmp_path, mocker):
     """Test copy_resource_s3 script"""
 
@@ -1189,8 +1203,8 @@ def test_copy_resource_s3(tmp_path, mocker):
         expected_params={
             'Body': botocore.stub.ANY,
             'Bucket': bucket,
-            'ContentType': 'application/json',
-            'Key': key_b,
+            'ContentType': ANY_OF(['application/json', 'image/jpeg']),
+            'Key': ANY_OF([key_b, key_a]),
         }
     )
     s3_stubber.add_response(
@@ -1199,8 +1213,8 @@ def test_copy_resource_s3(tmp_path, mocker):
         expected_params={
             'Body':  botocore.stub.ANY,
             'Bucket': bucket,
-            'ContentType': 'image/jpeg',
-            'Key': key_a,
+            'ContentType': ANY_OF(['application/json', 'image/jpeg']),
+            'Key': ANY_OF([key_b, key_a]),
         }
     )
     s3_stubber.activate()


### PR DESCRIPTION
We don't care about the order in which uploads occur, and there is potential for both the file system glob or the thread pool to reorder s3 uploads and checks. Botocore stubber does not support order-independent requests. This is all I could do to handle the race condition in the tests short of sending in a PR against botocore (which maybe wouldn't be a bad idea, because this is a missing feature in my eyes, and it would be better in terms of correctness)