### PR TITLE
Fix unconverted math issues in Google Docs

### DIFF
--- a/bakery/src/scripts/Dockerfile
+++ b/bakery/src/scripts/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.7-slim
 LABEL maintainer="OpenStax Content Engineering"
 
 RUN apt update
-RUN apt install -y build-essential libicu-dev pkg-config libmagic1 mime-support wget curl xsltproc pandoc
+RUN apt install -y build-essential libicu-dev pkg-config libmagic1 mime-support wget curl xsltproc
 
 COPY ./requirements.txt /code/scripts/
 WORKDIR /code/
@@ -11,6 +11,7 @@ WORKDIR /code/
 RUN pip install -r scripts/requirements.txt
 
 ENV JQ_VERSION='1.6'
+ENV PANDOC_VERSION='2.10.1'
 
 RUN wget --no-check-certificate https://raw.githubusercontent.com/stedolan/jq/master/sig/jq-release.key -O /tmp/jq-release.key && \
     wget --no-check-certificate https://raw.githubusercontent.com/stedolan/jq/master/sig/v${JQ_VERSION}/jq-linux64.asc -O /tmp/jq-linux64.asc && \
@@ -22,6 +23,10 @@ RUN wget --no-check-certificate https://raw.githubusercontent.com/stedolan/jq/ma
     rm -f /tmp/jq-release.key && \
     rm -f /tmp/jq-linux64.asc && \
     rm -f /tmp/jq-linux64
+
+RUN wget https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-1-amd64.deb -O /tmp/pandoc.deb && \
+    dpkg -i /tmp/pandoc.deb && \
+    rm -f /tmp/pandoc.deb
 
 COPY ./*.py ./*.json /code/scripts/
 COPY ./gdoc/ /code/gdoc/

--- a/bakery/src/scripts/gdocify_book.py
+++ b/bakery/src/scripts/gdocify_book.py
@@ -72,6 +72,19 @@ def update_doc_links(doc, book_uuid, book_slugs_by_uuid, page_slug_resolver):
             )
 
 
+def patch_math(doc):
+    """Patch MathML as needed for the conversion process used for gdocs"""
+
+    # It seems texmath used by pandoc has issues when the mathvariant
+    # attribute value of "bold-italic" is used with <mtext>, but these convert
+    # okay when the element is <mi>.
+    for node in doc.xpath(
+        '//x:mtext[@mathvariant="bold-italic"]',
+        namespaces={"x": "http://www.w3.org/1999/xhtml"}
+    ):
+        node.tag = "mi"
+
+
 def main():
     in_dir = Path(sys.argv[1]).resolve(strict=True)
     out_dir = Path(sys.argv[2]).resolve(strict=True)
@@ -105,6 +118,7 @@ def main():
             book_slugs_by_uuid,
             page_slug_resolver
         )
+        patch_math(doc)
         doc.write(str(out_dir / xhtml_file.name), encoding="utf8")
 
 

--- a/bakery/src/tests/test_bakery_scripts.py
+++ b/bakery/src/tests/test_bakery_scripts.py
@@ -1072,6 +1072,11 @@ def test_gdocify_book(tmp_path, mocker):
         <p><a id="l5"
             href="/contents/internal-uuid#foobar"
             class="target-chapter">Intra-book module link with fragment</a></p>
+        <math>
+            <mrow>
+                <mtext mathvariant="bold-italic">x</mtext>
+            </mrow>
+        </math>
         </div>
         </body>
         </html>
@@ -1151,6 +1156,12 @@ def test_gdocify_book(tmp_path, mocker):
         "//x:a[@href]", namespaces={"x": "http://www.w3.org/1999/xhtml"},
     ):
         assert expected_links_by_id[node.attrib["id"]] == node.attrib["href"]
+
+    for node in updated_doc.xpath(
+        '//x:*[@mathvariant="bold-italic"]',
+        namespaces={"x": "http://www.w3.org/1999/xhtml"},
+    ):
+        assert "mi" == node.tag.split("}")[1]
 
 
 class ANY_OF:


### PR DESCRIPTION
This PR fixes two issues which resulted in unconverted math in early Google Docs testing:

1. Broken conversions due to injection of `\mspace` when translated to LaTeX: This is fixed by updating our version of `pandoc` and underlying dependencies.
2. Broken conversions due to `<mtext>` elements with attribute `mathvariant="bold-italic"`: This is fixed by converting to `<mi>` as a workaround for `texmath` otherwise generating `LaTeX` which it causes it to error.

These changes should fix all math conversion warnings found during `convert-docx` when building Calculus Volume I (`col11964`) except for [3 errors in `m53596`](https://github.com/openstax/cnx/issues/1164#issuecomment-698604925) which should probably be addressed by content fixes instead of code patching. 