### PR TITLE
Add 1e books to canonical list

### DIFF
--- a/bakery/src/scripts/canonical-book-list.json
+++ b/bakery/src/scripts/canonical-book-list.json
@@ -137,12 +137,12 @@
             "_name": "Principles of Macroeconomics 1e"
         },
         {
-            "uuid": "33076054-ec1d-4417-8824-ce354efe42d0",
-            "_name": "Principles of Macroeconomics for AP Courses 1e"
-        },
-        {
             "uuid": "ea2f225e-6063-41ca-bcd8-36482e15ef65",
             "_name": "Principles of Microeconomics 1e"
+        },
+        {
+            "uuid": "33076054-ec1d-4417-8824-ce354efe42d0",
+            "_name": "Principles of Macroeconomics for AP Courses 1e"
         },
         {
             "uuid": "ca344e2d-6731-43cd-b851-a7b3aa0b37aa",

--- a/bakery/src/scripts/canonical-book-list.json
+++ b/bakery/src/scripts/canonical-book-list.json
@@ -103,6 +103,50 @@
         {
             "uuid": "fd53eae1-fa23-47c7-bb1b-972349835c3c",
             "_name": "Precalculus"
+        },
+        {
+            "uuid": "5bcc0e59-7345-421d-8507-a1e4608685e8",
+            "_name": "American Government 1e"
+        },
+        {
+            "uuid": "185cbf87-c72e-48f5-b51e-f14f21b5eabd",
+            "_name": "Biology 1e"
+        },
+        {
+            "uuid": "85abf193-2bd2-4908-8563-90b8a7ac8df6",
+            "_name": "Chemistry 1e"
+        },
+        {
+            "uuid": "4539ae23-1ccc-421e-9b25-843acbb6c4b0",
+            "_name": "Chemistry: Atoms First 1e"
+        },
+        {
+            "uuid": "b3c1e1d2-839c-42b0-a314-e119a8aafbdd",
+            "_name": "Concepts of Biology"
+        },
+        {
+            "uuid": "afe4332a-c97f-4fc4-be27-4e4d384a32d8",
+            "_name": "Introduction to Sociology 1e"
+        },
+        {
+            "uuid": "69619d2b-68f0-44b0-b074-a9b2bf90b2c6",
+            "_name": "Principles of Economics 1e"
+        },
+        {
+            "uuid": "4061c832-098e-4b3c-a1d9-7eb593a2cb31",
+            "_name": "Principles of Macroeconomics 1e"
+        },
+        {
+            "uuid": "33076054-ec1d-4417-8824-ce354efe42d0",
+            "_name": "Principles of Macroeconomics for AP Courses 1e"
+        },
+        {
+            "uuid": "ea2f225e-6063-41ca-bcd8-36482e15ef65",
+            "_name": "Principles of Microeconomics 1e"
+        },
+        {
+            "uuid": "ca344e2d-6731-43cd-b851-a7b3aa0b37aa",
+            "_name": "Principles of Microeconomics for AP Courses 1e"
         }
     ]
 }

--- a/bakery/src/tests/test_bakery_scripts.py
+++ b/bakery/src/tests/test_bakery_scripts.py
@@ -295,6 +295,26 @@ def test_canonical_list_order():
         names = [book["_name"] for book in books["canonical_books"]]
         assert {"College Algebra", "Precalculus"}.issubset(set(names))
         assert names.index("College Algebra") < names.index("Precalculus")
+        assert names.index("American Government 2e") < \
+            names.index("American Government 1e")
+        assert names.index("Biology 2e") < names.index("Biology 1e")
+        assert names.index("Chemistry 2e") < names.index("Chemistry 1e")
+        assert names.index("Chemistry 2e") < \
+            names.index("Chemistry: Atoms First 1e")
+        assert names.index("Biology 2e") < \
+            names.index("Concepts of Biology")
+        assert names.index("Introduction to Sociology 2e") < \
+            names.index("Introduction to Sociology 1e")
+        assert names.index("Principles of Economics 2e") < \
+            names.index("Principles of Economics 1e")
+        assert names.index("Principles of Economics 2e") < \
+            names.index("Principles of Macroeconomics 1e")
+        assert names.index("Principles of Economics 2e") < \
+            names.index("Principles of Macroeconomics for AP Courses 1e")
+        assert names.index("Principles of Economics 2e") < \
+            names.index("Principles of Microeconomics 1e")
+        assert names.index("Principles of Economics 2e") < \
+            names.index("Principles of Microeconomics for AP Courses 1e")
 
 
 def mock_link_extras(tmp_path, content_dict, contents_dict, extras_dict,

--- a/bakery/src/tests/test_bakery_scripts.py
+++ b/bakery/src/tests/test_bakery_scripts.py
@@ -293,28 +293,44 @@ def test_canonical_list_order():
     with open(canonical_list) as canonical:
         books = json.load(canonical)
         names = [book["_name"] for book in books["canonical_books"]]
-        assert {"College Algebra", "Precalculus"}.issubset(set(names))
-        assert names.index("College Algebra") < names.index("Precalculus")
-        assert names.index("American Government 2e") < \
-            names.index("American Government 1e")
-        assert names.index("Biology 2e") < names.index("Biology 1e")
-        assert names.index("Chemistry 2e") < names.index("Chemistry 1e")
-        assert names.index("Chemistry 2e") < \
-            names.index("Chemistry: Atoms First 1e")
-        assert names.index("Biology 2e") < \
-            names.index("Concepts of Biology")
-        assert names.index("Introduction to Sociology 2e") < \
-            names.index("Introduction to Sociology 1e")
-        assert names.index("Principles of Economics 2e") < \
-            names.index("Principles of Economics 1e")
-        assert names.index("Principles of Economics 2e") < \
-            names.index("Principles of Macroeconomics 1e")
-        assert names.index("Principles of Economics 2e") < \
-            names.index("Principles of Macroeconomics for AP Courses 1e")
-        assert names.index("Principles of Economics 2e") < \
-            names.index("Principles of Microeconomics 1e")
-        assert names.index("Principles of Economics 2e") < \
-            names.index("Principles of Microeconomics for AP Courses 1e")
+
+    assert {"College Algebra", "Precalculus"}.issubset(set(names))
+    assert names.index("College Algebra") < names.index("Precalculus")
+
+    # All 1e books should come after 2e variants
+    assert names.index("American Government 2e") < \
+        names.index("American Government 1e")
+    assert names.index("Biology 2e") < names.index("Biology 1e")
+    assert names.index("Chemistry 2e") < names.index("Chemistry 1e")
+    assert names.index("Chemistry 2e") < \
+        names.index("Chemistry: Atoms First 1e")
+    assert names.index("Biology 2e") < \
+        names.index("Concepts of Biology")
+    assert names.index("Introduction to Sociology 2e") < \
+        names.index("Introduction to Sociology 1e")
+    assert names.index("Principles of Economics 2e") < \
+        names.index("Principles of Economics 1e")
+    assert names.index("Principles of Economics 2e") < \
+        names.index("Principles of Macroeconomics 1e")
+    assert names.index("Principles of Economics 2e") < \
+        names.index("Principles of Macroeconomics for AP Courses 1e")
+    assert names.index("Principles of Economics 2e") < \
+        names.index("Principles of Microeconomics 1e")
+    assert names.index("Principles of Economics 2e") < \
+        names.index("Principles of Microeconomics for AP Courses 1e")
+
+    # Check for expected ordering within 1e variants
+    assert names.index("Biology 1e") < names.index("Concepts of Biology")
+    assert names.index("Chemistry 1e") < \
+        names.index("Chemistry: Atoms First 1e")
+    assert names.index("Principles of Economics 1e") < \
+        names.index("Principles of Macroeconomics 1e")
+    assert names.index("Principles of Macroeconomics 1e") < \
+        names.index("Principles of Microeconomics 1e")
+    assert names.index("Principles of Microeconomics 1e") < \
+        names.index("Principles of Macroeconomics for AP Courses 1e")
+    assert names.index("Principles of Macroeconomics for AP Courses 1e") < \
+        names.index("Principles of Microeconomics for AP Courses 1e")
 
 
 def mock_link_extras(tmp_path, content_dict, contents_dict, extras_dict,


### PR DESCRIPTION
There are cases where 1e books link to modules in other 1e books
that are not present in 2e versions leading to failures in
link-extras. We're adding 1e books as low priority entries to our
list so the books can be built without changing links to be 2e
equivalent modules.