### PR TITLE
start MathJax & json-rpc gracefully and use another port for json-rpc server

### DIFF
--- a/bakery/src/scripts/Dockerfile
+++ b/bakery/src/scripts/Dockerfile
@@ -30,7 +30,7 @@ RUN wget https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pando
 
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get install -y nodejs
-RUN npm install forever@3.0.2 -g
+RUN npm install pm2@4.5.0 -g
 
 COPY ./*.py ./*.js ./*.json /code/scripts/
 COPY ./gdoc/ /code/gdoc/

--- a/bakery/src/scripts/mathmltable2png.py
+++ b/bakery/src/scripts/mathmltable2png.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 DENSITY_DPI = 900
 IMG_SNIPPET = '<img src="{}" alt="{}" width="{}" height="{}" />'
-JSONRPC_URL = 'http://localhost:33001/jsonrpc'
+JSONRPC_URL = 'http://127.0.0.1:33001/jsonrpc'
 
 
 def force_math_namespace_only(doc):

--- a/bakery/src/scripts/mathmltable2png.py
+++ b/bakery/src/scripts/mathmltable2png.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 DENSITY_DPI = 900
 IMG_SNIPPET = '<img src="{}" alt="{}" width="{}" height="{}" />'
-JSONRPC_URL = 'http://localhost:3000/jsonrpc'
+JSONRPC_URL = 'http://localhost:33001/jsonrpc'
 
 
 def force_math_namespace_only(doc):

--- a/bakery/src/scripts/mml2svg2png-json-rpc.js
+++ b/bakery/src/scripts/mml2svg2png-json-rpc.js
@@ -94,11 +94,11 @@ MathJax.startup.promise.then(() => {
 
   server.http().listen(listenPort, () => {
     console.log('Listening on *:' + listenPort)
-    // If run with PM2 (try/catch block) we send ready signal to PM2
+    // If running with PM2 (try/catch block) we send ready signal to PM2
     try {
       process.send('ready')
     } catch (err) {
-      // do nothing because not run with PM2
+      // do nothing because not running with PM2
     }
   })
 }).catch(err => console.log(err))

--- a/bakery/src/scripts/mml2svg2png-json-rpc.js
+++ b/bakery/src/scripts/mml2svg2png-json-rpc.js
@@ -86,5 +86,5 @@ MathJax.startup.promise.then(() => {
     }
   })
 
-  server.http().listen(3000)
+  server.http().listen(33001)
 }).catch(err => console.log(err))

--- a/bakery/src/scripts/mml2svg2png-json-rpc.js
+++ b/bakery/src/scripts/mml2svg2png-json-rpc.js
@@ -1,7 +1,13 @@
 /* global MathJax:true */
 
-// run with:
+// How to run server manually:
 // node -r esm mml2svg2png-json-rpc.js
+//
+// How to run server with pm2:
+// pm2 start mml2svg2png-json-rpc.js --node-args="-r esm" --wait-ready --listen-timeout 8000
+
+// listen port
+const listenPort = 33001
 
 //
 // Mathjax options
@@ -86,5 +92,13 @@ MathJax.startup.promise.then(() => {
     }
   })
 
-  server.http().listen(33001)
+  server.http().listen(listenPort, () => {
+    console.log('Listening on *:' + listenPort)
+    // If run with PM2 (try/catch block) we send ready signal to PM2
+    try {
+      process.send('ready')
+    } catch (err) {
+      // do nothing because not run with PM2
+    }
+  })
 }).catch(err => console.log(err))

--- a/bakery/src/tasks/convert-docx.js
+++ b/bakery/src/tasks/convert-docx.js
@@ -31,7 +31,7 @@ const task = (taskArgs) => {
           dedent`
           exec 2> >(tee docx-book/stderr >&2)
           pushd /code/scripts
-          pm2 start mml2svg2png-json-rpc.js --node-args="-r esm"
+          pm2 start mml2svg2png-json-rpc.js --node-args="-r esm" --wait-ready --listen-timeout 8000
           popd
           cp -r gdocified-book/* docx-book
           collection_id="$(cat book/collection_id)"

--- a/bakery/src/tasks/convert-docx.js
+++ b/bakery/src/tasks/convert-docx.js
@@ -31,7 +31,7 @@ const task = (taskArgs) => {
           dedent`
           exec 2> >(tee docx-book/stderr >&2)
           pushd /code/scripts
-          forever start -c "node -r esm" mml2svg2png-json-rpc.js
+          pm2 start mml2svg2png-json-rpc.js --node-args="-r esm"
           popd
           cp -r gdocified-book/* docx-book
           collection_id="$(cat book/collection_id)"
@@ -49,9 +49,7 @@ const task = (taskArgs) => {
             xsltproc --output "$wrapped_tempfile" /code/gdoc/wrap-in-greybox.xsl "$mathmltable_tempfile"
             pandoc --reference-doc="/code/gdoc/custom-reference.docx" --from=html --to=docx --output="../../../$target_dir/$docx_filename" "$wrapped_tempfile"
           done
-          pushd /code/scripts
-          forever stop mml2svg2png-json-rpc.js
-          popd
+          pm2 stop mml2svg2png-json-rpc
         `
         /* eslint-enable no-template-curly-in-string */
         ]


### PR DESCRIPTION
* use another port which is most likely not used.
* use `pm2` because it seems more mature, with less npm deprecation warnings and also seems better maintained than `forever`
* start pm2 gracefully and wait for MathJax to load (promise)
