### PR TITLE
Add log retention policy for COPS pipeline

### DIFF
--- a/bakery/src/pipelines/cops.js
+++ b/bakery/src/pipelines/cops.js
@@ -23,6 +23,7 @@ const pipeline = (env) => {
     tag: lockedTag,
     ...env.dockerCredentials
   }
+  const buildLogRetentionDays = 14
 
   // FIXME: These mappings should be in the COPS resource
   const JobType = Object.freeze({
@@ -111,6 +112,9 @@ const pipeline = (env) => {
 
   const pdfJob = {
     name: 'PDF',
+    build_log_retention: {
+      days: buildLogRetentionDays
+    },
     plan: [
       { get: 'output-producer-pdf', trigger: true, version: 'every' },
       reportToOutputProducerPdf(Status.ASSIGNED),
@@ -151,6 +155,9 @@ const pipeline = (env) => {
 
   const distPreviewJob = {
     name: 'Distribution Preview',
+    build_log_retention: {
+      days: buildLogRetentionDays
+    },
     plan: [
       { get: 'output-producer-dist-preview', trigger: true, version: 'every' },
       reportToOutputProducerDistPreview(Status.ASSIGNED),


### PR DESCRIPTION
Adding a 14 day retention policy for COPS jobs (PDF and preview) as I think that seems reasonable in terms of a sliding window, and we probably don't want a strict build count in case there are bursts of activity around content development milestones where we may need Concourse log details to investigate errors. 