### PR TITLE
Add request-limit flag for bakery CLI fetch task

### DIFF
--- a/bakery/src/cli/execute.js
+++ b/bakery/src/cli/execute.js
@@ -309,9 +309,10 @@ const tasks = {
       const buildExec = path.resolve(BAKERY_PATH, 'build')
 
       const imageDetails = imageDetailsFromArgs(argv)
+      const nebGetFlags = argv.requestLimit == null ? '' : `--request-limit ${argv.requestLimit}`
       const taskArgs = imageDetails == null
         ? []
-        : [`--taskargs=${JSON.stringify(imageDetails)}`]
+        : [`--taskargs=${JSON.stringify({ ...imageDetails, nebGetFlags: nebGetFlags })}`]
       const taskContent = execFileSync(buildExec, ['task', 'fetch-book', ...taskArgs])
       const tmpTaskFile = tmp.fileSync()
       fs.writeFileSync(tmpTaskFile.name, taskContent)
@@ -344,6 +345,10 @@ const tasks = {
         }).positional('version', {
           describe: 'version of collection to fetch',
           type: 'string'
+        }).option('l', {
+          alias: 'request-limit',
+          describe: 'maximum number of concurrent requests to make',
+          type: 'number'
         })
       },
       handler: argv => {

--- a/bakery/src/tasks/fetch-book.js
+++ b/bakery/src/tasks/fetch-book.js
@@ -8,6 +8,7 @@ const task = (taskArgs) => {
     tag: 'trunk'
   }
   const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
+  const nebGetFlags = taskArgs != null && taskArgs.nebGetFlags != null ? taskArgs.nebGetFlags : ''
   const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })
   const bookSlugsUrl = 'https://raw.githubusercontent.com/openstax/content-manager-approved-books/master/book-slugs.json'
 
@@ -30,7 +31,7 @@ const task = (taskArgs) => {
           exec 2> >(tee fetched-book/stderr >&2)
           cd fetched-book
           book_dir="$(cat ../book/collection_id)"
-          yes | neb get -r -d "$book_dir/raw" "$(cat ../book/server)" "$(cat ../book/collection_id)" "$(cat ../book/version)"
+          yes | neb get ${nebGetFlags} -r -d "$book_dir/raw" "$(cat ../book/server)" "$(cat ../book/collection_id)" "$(cat ../book/version)"
           wget ${bookSlugsUrl} -O "$book_dir/book-slugs.json"
         `
         ]


### PR DESCRIPTION
This change exposes the corresponding flag for neb get which some
users have found necessary to avoid issues fetching books.