### PR TITLE
Support git-based job types in COPS

### DIFF
--- a/backend/app/app/data_models/models.py
+++ b/backend/app/app/data_models/models.py
@@ -50,7 +50,7 @@ class JobBase(BaseModel):
     status_id: str
     pdf_url: Optional[str] = None
     content_server_id: Optional[str] = None
-    version: str = None  # Git: ref
+    version: Optional[str] = None  # Git: ref
     style: Optional[str] = None
     job_type_id: str
 

--- a/backend/app/app/data_models/models.py
+++ b/backend/app/app/data_models/models.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from pydantic import BaseModel
+from typing import Optional
 
 
 class StatusBase(BaseModel):
@@ -30,7 +31,13 @@ class ContentServer(ContentServerBase):
 class JobTypeBase(BaseModel):
     name: str
 
-
+# Types:
+### Archive
+# 1: pdf
+# 2: distribution-preview
+### Git
+# 3: git-pdf
+# 4: git-distribution-preview
 class JobType(JobTypeBase):
     id: str
 
@@ -39,13 +46,13 @@ class JobType(JobTypeBase):
 
 
 class JobBase(BaseModel):
-    collection_id: str
+    collection_id: str  # Git: '{repo}/{slug}'
     status_id: str
-    pdf_url: str = None
-    content_server_id: str
-    version: str = None
-    style: str = None
-    job_type_id: str = "1"
+    pdf_url: Optional[str] = None
+    content_server_id: Optional[str] = None
+    version: str = None  # Git: ref
+    style: Optional[str] = None
+    job_type_id: str
 
 
 class JobCreate(JobBase):
@@ -62,7 +69,7 @@ class Job(JobBase):
     created_at: datetime
     updated_at: datetime
     status: Status
-    content_server: ContentServer
+    content_server: Optional[ContentServer]
     job_type: JobType
 
     class Config:

--- a/backend/app/migrations/versions/0eee70848f87_add_seed_data_for_git_job_types.py
+++ b/backend/app/migrations/versions/0eee70848f87_add_seed_data_for_git_job_types.py
@@ -1,0 +1,46 @@
+"""add seed data for git job types
+
+Revision ID: 0eee70848f87
+Revises: cc7ec89e9135
+Create Date: 2020-11-05 20:34:27.770606
+
+"""
+from datetime import datetime
+
+from alembic import op
+import sqlalchemy as sa
+
+from app.data_models.models import JobType
+
+
+# revision identifiers, used by Alembic.
+revision = '0eee70848f87'
+down_revision = 'cc7ec89e9135'
+branch_labels = None
+depends_on = None
+
+job_types_table = sa.table('job_types',
+                        sa.column('id', sa.Integer),
+                        sa.column('name', sa.String),
+                        sa.column('created_at', sa.DateTime),
+                        sa.column('updated_at', sa.DateTime)
+                        )
+
+jobs_table = sa.table('jobs', sa.column('job_type_id'))
+
+def upgrade():
+    utcnow = datetime.utcnow()
+    server_data = [{'id': 3, 'name': 'git-pdf', 'created_at': utcnow, 'updated_at': utcnow},
+                   {'id': 4, 'name': 'git-distribution-preview', 'created_at': utcnow, 'updated_at': utcnow}]
+
+    bind = op.get_bind()
+    insert = job_types_table.insert().values(server_data)
+    bind.execute(insert)
+
+
+def downgrade():
+    bind = op.get_bind()
+    delete_jobs_of_seeded_type = jobs_table.delete().where(jobs_table.c.job_type_id.in_([3,4]))
+    delete_seed = job_types_table.delete().where(job_types_table.c.id.in_([3,4]))
+    bind.execute(delete_jobs_of_seeded_type)
+    bind.execute(delete_seed)

--- a/backend/app/tests/integration/api/endpoints/test_jobs.py
+++ b/backend/app/tests/integration/api/endpoints/test_jobs.py
@@ -28,7 +28,8 @@ def test_jobs_post_request_successful(api_url):
     data = {
         "collection_id": "abc123",
         "status_id": "1",
-        "content_server_id": "1"
+        "content_server_id": "1",
+        "job_type_id": "1"
     }
 
     # WHEN: A POST request is made to the url with data
@@ -43,4 +44,5 @@ def test_jobs_post_request_successful(api_url):
     assert response["collection_id"] == "abc123"
     assert response["content_server"]["hostname"] == "content01.cnx.org"
     assert response["status"]["name"] == "queued"
+    assert response["job_type"]["name"] == "pdf"
 

--- a/backend/app/tests/ui/pages/home.py
+++ b/backend/app/tests/ui/pages/home.py
@@ -74,7 +74,7 @@ class Home(Page):
 
         _modal_status_message_locator = (
             By.XPATH,
-            "/html/body/div/div/div/div/main/div/div/div/div/div[3]/div/table/tbody/tr[1]/td[8]/span/span/span",
+            "//div[contains(@class,'jobs-table')]/div/table/tbody/tr[1]/td[8]/span/span/span",
         )
 
         @property

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -152,7 +152,7 @@
         :items="jobs"
         :disable-pagination="true"
         :hide-default-footer="true"
-        class="elevation-1"
+        class="elevation-1 jobs-table"
       >
         <template v-slot:item.created_at="{ item }">
           <span>

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -41,13 +41,15 @@
                     <v-radio-group v-model="jobType" row mandatory :default="jobTypes.PDF">
                       <v-radio label="PDF" :value="jobTypes.PDF" class="pdf-radio-button"></v-radio>
                       <v-radio label="Distribution Preview" :value="jobTypes.DIST_PREVIEW" class="preview-radio-button"></v-radio>
+                      <v-radio disabled label="PDF (git)" :value="jobTypes.GIT_PDF" class="git-pdf-radio-button"></v-radio>
+                      <v-radio disabled label="Distribution Preview (git)" :value="jobTypes.GIT_DIST_PREVIEW" class="git-preview-radio-button"></v-radio>
                     </v-radio-group>
                   </v-row>
                   <v-row>
                     <v-col cols="12" sm="3" md="3">
                       <v-text-field
                         v-model="collectionId"
-                        :rules="[v => !!v || 'Collection ID is required', v => /^col\d*$/.test(v) || 'A valid collection ID is required, e.g. col12345']"
+                        :rules="usingArchive() ? collectionRules : gitCollectionRules"
                         label="Collection ID"
                         class="collection-id-error-text collection-id-incorrect-error-text collection-id-field"
                         hint="e.g. col12345"
@@ -66,8 +68,9 @@
                     <v-col cols="12" sm="3" md="3">
                       <v-combobox
                         v-model="style"
-                        :rules="[v => !!v || 'Style is required']"
+                        :rules="usingArchive() ? styleRules : []"
                         :items="styleItems"
+                        :disabled="!usingArchive()"
                         hint="e.g. microbiology"
                         label="Style"
                         class="style-error-text style-field"
@@ -78,7 +81,8 @@
                       <v-select
                         v-model="contentServerId"
                         :items="content_servers"
-                        :rules="[v => !!v || 'Please select a server']"
+                        :rules="usingArchive() ? serverRules : []"
+                        :disabled="!usingArchive()"
                         label="Content Server"
                         class="server-error-text server-field"
                         required
@@ -97,7 +101,7 @@
               <v-btn @click="closeDialog()" class="job-cancel-button" color="blue darken-1" text>
                 Cancel
               </v-btn>
-              <v-btn @click="clickCollection(collectionId, contentServerId, version, style, jobType)" class="create-button-start-job" color="blue darken-1" text>
+              <v-btn @click="clickCollection(collectionId, maybeContentServerId, version, maybeStyle, jobType)" class="create-button-start-job" color="blue darken-1" text>
                 Create
               </v-btn>
             </v-card-actions>
@@ -192,26 +196,7 @@
 
 export default {
   data () {
-    // This value corresponds to the seeded id in the backend
-    this.jobTypes = { PDF: 1, DIST_PREVIEW: 2 }
     return {
-      headers: [
-        {
-          text: 'Job ID',
-          align: 'left',
-          sortable: true,
-          value: 'id'
-        },
-        { text: 'Job Type', value: 'job_type_name' },
-        { text: 'Collection ID', value: 'collection_id' },
-        { text: 'Version', value: 'version' },
-        { text: 'Style', value: 'style' },
-        { text: 'Start Date and Time', value: 'created_at' },
-        { text: 'Download URL', value: 'pdf_url' },
-        { text: 'Status', value: 'status_name' },
-        { text: 'Content Server', value: 'content_server_name' },
-        { text: 'Updated at', value: 'updated_at' }
-      ],
       dialog: false,
       collectionId: '',
       version: '',
@@ -225,40 +210,6 @@ export default {
       page_limit: 50,
       goto_page_limit: '50',
       valid: false,
-      collectionRules: [
-        v => !!v || 'Collection ID is required',
-        v => /^col\d*$/.test(v) || 'A valid collection ID is required, e.g. col12345'
-      ],
-      styleItems: [
-        'accounting',
-        'american-government',
-        'anatomy',
-        'ap-biology',
-        'ap-history',
-        'ap-physics',
-        'astronomy',
-        'biology',
-        'business-ethics',
-        'calculus',
-        'chemistry',
-        'college-success',
-        'dev-math',
-        'economics',
-        'entrepreneurship',
-        'history',
-        'hs-physics',
-        'intro-business',
-        'microbiology',
-        'college-physics',
-        'pl-u-physics',
-        'precalculus',
-        'precalculus-coreq',
-        'principles-management',
-        'psychology',
-        'sociology',
-        'statistics',
-        'u-physics'
-      ]
     }
   },
   computed: {
@@ -267,7 +218,76 @@ export default {
     },
     content_servers () {
       return this.$store.getters.content_servers_items
+    },
+    maybeContentServerId () {
+      return this.usingArchive() ? this.contentServerId : null
+    },
+    maybeStyle () {
+      return this.usingArchive() ? this.style : null
     }
+  },
+  // Init non-reactive data
+  beforeCreate () {
+    this.styleItems = [
+      'accounting',
+      'american-government',
+      'anatomy',
+      'ap-biology',
+      'ap-history',
+      'ap-physics',
+      'astronomy',
+      'biology',
+      'business-ethics',
+      'calculus',
+      'chemistry',
+      'college-success',
+      'dev-math',
+      'economics',
+      'entrepreneurship',
+      'history',
+      'hs-physics',
+      'intro-business',
+      'microbiology',
+      'college-physics',
+      'pl-u-physics',
+      'precalculus',
+      'precalculus-coreq',
+      'principles-management',
+      'psychology',
+      'sociology',
+      'statistics',
+      'u-physics'
+    ]
+    this.collectionRules = [
+      v => !!v || 'Collection ID is required',
+      v => /^col\d*$/.test(v) || 'A valid collection ID is required, e.g. col12345'
+    ],
+    this.styleRules = [v => !!v || 'Style is required']
+    this.serverRules = [v => !!v || 'Please select a server']
+    this.gitCollectionRules = [
+      v => !!v || 'Repo and slug are required',
+      v => /[a-zA-Z0-9-_]+\/[a-zA-Z0-9-_]+/.test(v) || 'repo-name/slug-name'
+    ]
+    this.usingArchive = () => [1,2].includes(this.jobType)
+    this.headers = [
+      {
+        text: 'Job ID',
+        align: 'left',
+        sortable: true,
+        value: 'id'
+      },
+      { text: 'Job Type', value: 'job_type_name' },
+      { text: 'Collection ID', value: 'collection_id' },
+      { text: 'Version', value: 'version' },
+      { text: 'Style', value: 'style' },
+      { text: 'Start Date and Time', value: 'created_at' },
+      { text: 'Download URL', value: 'pdf_url' },
+      { text: 'Status', value: 'status_name' },
+      { text: 'Content Server', value: 'content_server_name' },
+      { text: 'Updated at', value: 'updated_at' }
+    ],
+    // This value corresponds to the seeded id in the backend
+    this.jobTypes = { PDF: 1, DIST_PREVIEW: 2, GIT_PDF: 3, GIT_DIST_PREVIEW: 4 }
   },
   created () {
     this.getJobsImmediate()

--- a/scripts/tests.local.sh
+++ b/scripts/tests.local.sh
@@ -15,6 +15,7 @@ docker-compose \
     -f docker-compose.shared.depends.yml \
     -f docker-compose.shared.env.yml \
     -f docker-compose.dev.build.yml \
+    -f docker-compose.dev.command.yml \
     -f docker-compose.dev.images.yml \
     -f docker-compose.dev.env.yml \
     -f docker-compose.dev.labels.yml \

--- a/scripts/tests.local.sh
+++ b/scripts/tests.local.sh
@@ -24,8 +24,6 @@ docker-compose \
     -f docker-compose.dev.volumes.yml \
     config > docker-stack.yml
 
-#    -f docker-compose.dev.command.yml \
-
 docker-compose -f docker-stack.yml build
 docker-compose -f docker-stack.yml down -v --remove-orphans # Remove possibly previous broken stacks left hanging after an error
 docker-compose -f docker-stack.yml up -d


### PR DESCRIPTION
Job types are not selectable at this time, since there is no pipeline
that supports dequeuing these jobs, but once there are, the
infrastructure and validation is now there to handle them in COPS. The
radio buttons can simply be enabled at that point.

One slight restructure was done in the frontend, and that was to put
data that does not need to be reactive into beforeCreate. Seems to be
the more idiomatic way of handling "constant" data in Vue.

Part of the work for https://github.com/openstax/cnx/issues/1233