### PR TITLE
Report failures in git pdf job - prevent failure in fetch-book-group

### DIFF
--- a/bakery/README.md
+++ b/bakery/README.md
@@ -111,7 +111,7 @@ When generating pipelines for the local environment, the following environment v
 | `AWS_SECRET_ACCESS_KEY` | Yes | AWS credentials (likely for our sandbox) |
 | `DOCKERHUB_USERNAME` | No | Your Docker Hub credentials (only needed if you're hitting rate limits otherwise) |
 | `DOCKERHUB_PASSWORD` | No | Your Docker Hub credentials (only needed if you're hitting rate limits otherwise) |
-| `GH_SECRET_CREDS` | Yes | Your GitHub username with a GitHub personal access token. Colon separated (e.g. `my-username:12345abcdef...`) |
+| `GH_SECRET_CREDS` | Yes | A GitHub personal access token. |
 
 #### Generate a pipeline file for a particular environment
 Run `./build pipeline <pipelinetype> [options] <env> [options]...`

--- a/bakery/env/prod.json
+++ b/bakery/env/prod.json
@@ -15,7 +15,7 @@
   "GDOC_GOOGLE_FOLDER_ID": "",
   "GDOC_QUEUE_FILENAME": "",
   "GDOC_FEED_FILE_URL": "",
-  "GH_SECRET_CREDS": "((github-username)):((github-api-token))",
+  "GH_SECRET_CREDS": "((github-api-token))",
   "DOCKERHUB_USERNAME": "((ce-dockerhub-id))",
   "DOCKERHUB_PASSWORD": "((ce-dockerhub-token))"
 }

--- a/bakery/env/staging.json
+++ b/bakery/env/staging.json
@@ -15,7 +15,7 @@
   "GDOC_GOOGLE_FOLDER_ID": "",
   "GDOC_QUEUE_FILENAME": "",
   "GDOC_FEED_FILE_URL": "",
-  "GH_SECRET_CREDS": "((github-username)):((github-api-token))",
+  "GH_SECRET_CREDS": "((github-api-token))",
   "DOCKERHUB_USERNAME": "((ce-dockerhub-id))",
   "DOCKERHUB_PASSWORD": "((ce-dockerhub-token))"
 }

--- a/bakery/src/pipelines/cops.js
+++ b/bakery/src/pipelines/cops.js
@@ -127,6 +127,9 @@ const pipeline = (env) => {
 
   const gitPdfJob = {
     name: 'PDF (git)',
+    build_log_retention: {
+      days: buildLogRetentionDays
+    },
     plan: [
       { get: 'output-producer-git-pdf', trigger: true, version: 'every' },
       reportToOutputProducerGitPdf(Status.ASSIGNED),

--- a/bakery/src/pipelines/cops.js
+++ b/bakery/src/pipelines/cops.js
@@ -152,7 +152,13 @@ const pipeline = (env) => {
           content_type: 'application/pdf'
         }
       }
-    ]
+    ],
+    on_success: reportToOutputProducerGitPdf(Status.SUCCEEDED, {
+      pdf_url: 'artifacts-single/pdf_url'
+    }),
+    on_failure: reportToOutputProducerGitPdf(Status.FAILED),
+    on_error: reportToOutputProducerGitPdf(Status.FAILED),
+    on_abort: reportToOutputProducerGitPdf(Status.FAILED)
   }
 
   const pdfJob = {


### PR DESCRIPTION
turns out github-username was an email and broke everything. used a suggestion from @rnathuji to use only the github api access token in the github fetch link and it seems to work!