### PR TITLE
live-reload fix

### DIFF
--- a/backend/app/bin/prestart-dev.sh
+++ b/backend/app/bin/prestart-dev.sh
@@ -7,4 +7,4 @@ python ./bin/db_wait.py
 alembic upgrade head
 
 # shellcheck source=SCRIPTDIR/live-reload.sh
-source ./live-reload.sh
+source ./bin/live-reload.sh


### PR DESCRIPTION
Fixing a missing path in `prestart-dev.sh` for `live-reload.sh` introduced during `shellcheck` changes.