### PR TITLE
remove annotation-xml nodes

### DIFF
--- a/bakery/src/scripts/gdoc/wrap-in-greybox.xsl
+++ b/bakery/src/scripts/gdoc/wrap-in-greybox.xsl
@@ -114,6 +114,10 @@
   </div>
 </xsl:template>
 
+<!-- remove annotation-xml nodes which confuses MathJax especially on StarMath annotations -->
+<xsl:template match="h:annotation-xml[ancestor::h:math]" mode="grey"/>
+<xsl:template match="h:annotation-xml[ancestor::h:math]"/>
+
 <!-- make block math to inline also for non grey background math -->
 <!-- note: pandoc ignores text center property https://github.com/jgm/pandoc/issues/719 -->
 <xsl:template match="h:math[@display='block']">

--- a/bakery/src/scripts/gdoc/wrap-in-greybox.xsl
+++ b/bakery/src/scripts/gdoc/wrap-in-greybox.xsl
@@ -114,10 +114,6 @@
   </div>
 </xsl:template>
 
-<!-- remove annotation-xml nodes which confuses MathJax especially on StarMath annotations -->
-<xsl:template match="h:annotation-xml[ancestor::h:math]" mode="grey"/>
-<xsl:template match="h:annotation-xml[ancestor::h:math]"/>
-
 <!-- make block math to inline also for non grey background math -->
 <!-- note: pandoc ignores text center property https://github.com/jgm/pandoc/issues/719 -->
 <xsl:template match="h:math[@display='block']">

--- a/bakery/src/scripts/gdocify_book.py
+++ b/bakery/src/scripts/gdocify_book.py
@@ -95,7 +95,7 @@ def patch_math(doc):
 
     # MathJax 3.x behaves different than legacy MathJax 2.7.x on msubsup MathML.
     # If msubsup has fewer than 3 elements MathJax 3.x does not convert it to
-    # msub itself anymore. We are keeping sure in this step that all msubsup 
+    # msub itself anymore. We are keeping sure in this step that all msubsup
     # with fewer elements than 3 are converted to msub.
     for node in doc.xpath(
         '//x:msubsup[count(*) < 3]',

--- a/bakery/src/scripts/gdocify_book.py
+++ b/bakery/src/scripts/gdocify_book.py
@@ -92,6 +92,12 @@ def patch_math(doc):
         namespaces={"x": "http://www.w3.org/1999/xhtml"}
     ):
         node.getparent().remove(node)
+    # also do an extra check for StarMath annotation tags
+    for node in doc.xpath(
+        '//x:annotation[starts-with(@encoding, 'Star')]',
+        namespaces={"x": "http://www.w3.org/1999/xhtml"}
+    ):
+        node.getparent().remove(node)
 
     # MathJax 3.x behaves different than legacy MathJax 2.7.x on msubsup MathML.
     # If msubsup has fewer than 3 elements MathJax 3.x does not convert it to

--- a/bakery/src/scripts/gdocify_book.py
+++ b/bakery/src/scripts/gdocify_book.py
@@ -84,7 +84,7 @@ def patch_math(doc):
     ):
         node.tag = "mi"
 
-    # MathJax 3.x renders StarMath annotation
+    # Pandoc renders StarMath annotation
     # which is btw out of specification of MathML.
     # The following lines removes all annotation-xml nodes.
     for node in doc.xpath(
@@ -92,9 +92,9 @@ def patch_math(doc):
         namespaces={"x": "http://www.w3.org/1999/xhtml"}
     ):
         node.getparent().remove(node)
-    # also do an extra check for StarMath annotation tags
+    # remove also all annotation nodes which can confuse Pandoc
     for node in doc.xpath(
-        '//x:annotation[starts-with(@encoding, 'Star')]',
+        '//x:annotation[ancestor::x:math]',
         namespaces={"x": "http://www.w3.org/1999/xhtml"}
     ):
         node.getparent().remove(node)
@@ -103,6 +103,7 @@ def patch_math(doc):
     # If msubsup has fewer than 3 elements MathJax 3.x does not convert it to
     # msub itself anymore. We are keeping sure in this step that all msubsup
     # with fewer elements than 3 are converted to msub.
+    # Pandoc is also confused by msubsup with elements fewer than 3.
     for node in doc.xpath(
         '//x:msubsup[count(*) < 3]',
         namespaces={"x": "http://www.w3.org/1999/xhtml"}

--- a/bakery/src/scripts/gdocify_book.py
+++ b/bakery/src/scripts/gdocify_book.py
@@ -84,6 +84,15 @@ def patch_math(doc):
     ):
         node.tag = "mi"
 
+    # MathJax 3.x renders StarMath annotation
+    # which is btw out of specification of MathML.
+    # The following lines removes all annotation-xml nodes.
+    for node in doc.xpath(
+        '//x:annotation-xml[ancestor::x:math]',
+        namespaces={"x": "http://www.w3.org/1999/xhtml"}
+    ):
+        node.getparent().remove(node)
+
 
 def main():
     in_dir = Path(sys.argv[1]).resolve(strict=True)

--- a/bakery/src/scripts/gdocify_book.py
+++ b/bakery/src/scripts/gdocify_book.py
@@ -93,6 +93,16 @@ def patch_math(doc):
     ):
         node.getparent().remove(node)
 
+    # MathJax 3.x behaves different than legacy MathJax 2.7.x on msubsup MathML.
+    # If msubsup has fewer than 3 elements MathJax 3.x does not convert it to
+    # msub itself anymore. We are keeping sure in this step that all msubsup 
+    # with fewer elements than 3 are converted to msub.
+    for node in doc.xpath(
+        '//x:msubsup[count(*) < 3]',
+        namespaces={"x": "http://www.w3.org/1999/xhtml"}
+    ):
+        node.tag = "msub"
+
 
 def main():
     in_dir = Path(sys.argv[1]).resolve(strict=True)

--- a/bakery/src/tests/test_bakery_scripts.py
+++ b/bakery/src/tests/test_bakery_scripts.py
@@ -1270,7 +1270,7 @@ def test_gdocify_book(tmp_path, mocker):
     assert len(unwanted_nodes) == 0
 
     unwanted_nodes = updated_doc.xpath(
-        '//x:annotation[@encoding="StarMath 5.0"]',
+        '//x:annotation',
         namespaces={"x": "http://www.w3.org/1999/xhtml"},
     )
     assert len(unwanted_nodes) == 0

--- a/bakery/src/tests/test_bakery_scripts.py
+++ b/bakery/src/tests/test_bakery_scripts.py
@@ -1165,7 +1165,8 @@ def test_gdocify_book(tmp_path, mocker):
                             </mrow>
                             <mrow></mrow>
                         </mrow>
-                        <annotation encoding="StarMath 5.0"> size 12{ { {N}} sup { x } rSub { size 8{R} } } {}</annotation>
+<!-- indent differently because of flake8 -->
+<annotation encoding="StarMath 5.0"> size 12{ { {N}} sup { x } rSub { size 8{R} } } {}</annotation>
                     </semantics>
                 </annotation-xml>
             </semantics>

--- a/bakery/src/tests/test_bakery_scripts.py
+++ b/bakery/src/tests/test_bakery_scripts.py
@@ -1131,6 +1131,45 @@ def test_gdocify_book(tmp_path, mocker):
                 <mtext mathvariant="bold-italic">x</mtext>
             </mrow>
         </math>
+        <math>
+            <semantics>
+                <mrow>
+                    <mrow>
+                        <mrow>
+                            <msubsup>
+                                <mrow>
+                                    <mi>N</mi>
+                                    <mo>′</mo>
+                                </mrow>
+                                <mrow>
+                                    <mtext>R</mtext>
+                                </mrow>
+                            </msubsup>
+                        </mrow>
+                        <mrow></mrow>
+                    </mrow>
+                </mrow>
+                <annotation-xml encoding="MathML-Content">
+                    <semantics>
+                        <mrow>
+                            <mrow>
+                                <msubsup>
+                                    <mrow>
+                                        <mi>N</mi>
+                                        <mo>′</mo>
+                                    </mrow>
+                                    <mrow>
+                                        <mtext>R</mtext>
+                                    </mrow>
+                                </msubsup>
+                            </mrow>
+                            <mrow></mrow>
+                        </mrow>
+                        <annotation encoding="StarMath 5.0"> size 12{ { {N}} sup { x } rSub { size 8{R} } } {}</annotation>
+                    </semantics>
+                </annotation-xml>
+            </semantics>
+        </math>
         </div>
         </body>
         </html>
@@ -1216,6 +1255,36 @@ def test_gdocify_book(tmp_path, mocker):
         namespaces={"x": "http://www.w3.org/1999/xhtml"},
     ):
         assert "mi" == node.tag.split("}")[1]
+
+    unwanted_nodes = updated_doc.xpath(
+        '//x:annotation-xml',
+        namespaces={"x": "http://www.w3.org/1999/xhtml"},
+    )
+    assert len(unwanted_nodes) == 0
+
+    unwanted_nodes = updated_doc.xpath(
+        '//x:annotation[@encoding="StarMath 5.0"]',
+        namespaces={"x": "http://www.w3.org/1999/xhtml"},
+    )
+    assert len(unwanted_nodes) == 0
+
+    unwanted_nodes = updated_doc.xpath(
+        '//x:msubsup[count(*) < 3]',
+        namespaces={"x": "http://www.w3.org/1999/xhtml"},
+    )
+    assert len(unwanted_nodes) == 0
+
+    unwanted_nodes = updated_doc.xpath(
+        '//x:msub[count(*) > 2]',
+        namespaces={"x": "http://www.w3.org/1999/xhtml"},
+    )
+    assert len(unwanted_nodes) == 0
+
+    msub_nodes = updated_doc.xpath(
+        '//x:msub',
+        namespaces={"x": "http://www.w3.org/1999/xhtml"},
+    )
+    assert len(msub_nodes) == 1
 
 
 class ANY_OF:

--- a/bakery/src/tests/test_bakery_scripts.py
+++ b/bakery/src/tests/test_bakery_scripts.py
@@ -1171,6 +1171,12 @@ def test_gdocify_book(tmp_path, mocker):
                 </annotation-xml>
             </semantics>
         </math>
+        <math>
+            <semantics>
+                <mi>N</mi>
+                <annotation encoding="StarMath 5.0">{N}</annotation>
+            </semantics>
+        </math>
         </div>
         </body>
         </html>


### PR DESCRIPTION
clean up MathML

* remove `annotation-xml` and `annotation` from MathML
* convert `msubsup` to `msub` if less than 3 elements inside.