### PR TITLE
do not stop pipeline on not found resources

### DIFF
--- a/bakery/src/scripts/gdocify_book.py
+++ b/bakery/src/scripts/gdocify_book.py
@@ -139,7 +139,7 @@ def fix_jpeg_colorspace(doc, out_dir):
                     # do nothing if we cannot open the image
                     print('Warning: Could not parse JPEG image with PIL: ' + str(img_filename))
         else:
-            raise Exception('Error: Resource file not existing: ' + str(img_filename))
+            print('Warning: Resource file not existing: ' + str(img_filename))
 
 
 def main():

--- a/bakery/src/tests/test_bakery_scripts.py
+++ b/bakery/src/tests/test_bakery_scripts.py
@@ -1496,8 +1496,8 @@ def test_gdocify_book(tmp_path, mocker):
             </html>
         """
         doc = etree.fromstring(xhtml)
-        with pytest.raises(Exception, match=r'^Error: Resource file not existing:.*'):
-            gdocify_book.fix_jpeg_colorspace(doc, Path(temp_dir))
+        # should not give any error messages:
+        gdocify_book.fix_jpeg_colorspace(doc, Path(temp_dir))
 
         copy_tree(TEST_JPEG_DIR, temp_dir)  # reset test case
         im = Image.open(os.path.join(temp_dir, cmyk))

--- a/bakery/src/tests/test_bakery_scripts.py
+++ b/bakery/src/tests/test_bakery_scripts.py
@@ -1485,8 +1485,8 @@ def test_gdocify_book(tmp_path, mocker):
             </html>
         """
         doc = etree.fromstring(xhtml)
-        with pytest.raises(Exception, match=r'^Error\: Resource file not existing\:.*'):
-            gdocify_book.fix_jpeg_colorspace(doc, Path(temp_dir))
+        # should not give any error messages:
+        gdocify_book.fix_jpeg_colorspace(doc, Path(temp_dir))
 
         xhtml = """
             <html xmlns="http://www.w3.org/1999/xhtml">


### PR DESCRIPTION
Pipeline was stopped on collections:

* col26488
* col12081

error message at `col26488` on [gdocify step](https://concourse-v6.openstax.org/teams/CE/pipelines/gdoc-staging-cnx1322/jobs/bakery/builds/16):
```
+ exec
++ tee gdocified-book/stderr
+ cp -r disassembled-book/col26488 disassembled-book/stderr gdocified-book
++ cat book/collection_id
+ collection_id=col26488
+ book_dir=gdocified-book/col26488/disassembled
+ target_dir=gdocified-book/col26488/gdocified
+ book_slugs_file=gdocified-book/col26488/book-slugs.json
+ mkdir gdocified-book/col26488/gdocified
+ gdocify gdocified-book/col26488/disassembled gdocified-book/col26488/gdocified gdocified-book/col26488/book-slugs.json
Convert to RGB: ../resources/8a9dbdef9a6d7a62ea4da8fb4adb2f3f2d7566af
Convert to RGB: ../resources/2b721b0944b10dcfed1a88cb056a233b350838a9
Convert to RGB: ../resources/327c34078f002af621d6034ce19b6b1020691d97
Traceback (most recent call last):
  File "/usr/local/bin/gdocify", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/site-packages/bakery_scripts/gdocify_book.py", line 174, in main
    fix_jpeg_colorspace(doc, out_dir)
  File "/usr/local/lib/python3.7/site-packages/bakery_scripts/gdocify_book.py", line 142, in fix_jpeg_colorspace
    raise Exception('Error: Resource file not existing: ' + str(img_filename))
Exception: Error: Resource file not existing: /tmp/build/36dafd0d/gdocified-book/col26488/gdocified/CNX_Chem_20_01_alkanes.jpg
```

error message at `col12081` on [gdocify step](https://concourse-v6.openstax.org/teams/CE/pipelines/gdoc-staging-cnx1322/jobs/bakery/builds/17):
```
+ exec
++ tee gdocified-book/stderr
+ cp -r disassembled-book/col12081 disassembled-book/stderr gdocified-book
++ cat book/collection_id
+ collection_id=col12081
+ book_dir=gdocified-book/col12081/disassembled
+ target_dir=gdocified-book/col12081/gdocified
+ book_slugs_file=gdocified-book/col12081/book-slugs.json
+ mkdir gdocified-book/col12081/gdocified
+ gdocify gdocified-book/col12081/disassembled gdocified-book/col12081/gdocified gdocified-book/col12081/book-slugs.json
Convert to RGB: ../resources/832b66982e7fe1b3aa3adbb1d44e90dd9a29a5c5
Traceback (most recent call last):
  File "/usr/local/bin/gdocify", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/site-packages/bakery_scripts/gdocify_book.py", line 174, in main
    fix_jpeg_colorspace(doc, out_dir)
  File "/usr/local/lib/python3.7/site-packages/bakery_scripts/gdocify_book.py", line 142, in fix_jpeg_colorspace
    raise Exception('Error: Resource file not existing: ' + str(img_filename))
Exception: Error: Resource file not existing: /tmp/build/36dafd0d/gdocified-book/col12081/gdocified/openstax.org/l/28collisionlab
```