### PR TITLE
Remove use of obsolete JSON input files for git bakery tasks

### DIFF
--- a/bakery/src/scripts/assemble_book_group.sh
+++ b/bakery/src/scripts/assemble_book_group.sh
@@ -11,7 +11,6 @@ for collection in "${RAW_COLLECTION_DIR}/collections/"*; do
         fi
     fi
     mv "$collection" "${RAW_COLLECTION_DIR}/modules/collection.xml"
-    mv "${RAW_COLLECTION_DIR}/metadata/$slug_name.metadata.json" "${RAW_COLLECTION_DIR}/modules/metadata.json"
 
     neb assemble "${RAW_COLLECTION_DIR}/modules" temp-assembly/
 

--- a/bakery/src/scripts/bake_book_metadata.py
+++ b/bakery/src/scripts/bake_book_metadata.py
@@ -17,7 +17,11 @@ def main():
         metadata = DocumentMetadataParser(html)
         binder = reconstitute(baked_xhtml)
 
-    required_metadata = ('title', 'revised')
+    if book_slugs_file:
+        required_metadata = ('title', 'revised')
+    else:
+        required_metadata = ('title', 'revised', 'slug')
+
     for required_data in required_metadata:
         if getattr(metadata, required_data) is None:
             raise ValueError(
@@ -27,20 +31,34 @@ def main():
     with open(raw_metadata_file, "r") as raw_json:
         baked_metadata = json.load(raw_json)
 
-    with open(book_slugs_file, "r") as json_file:
-        json_data = json.load(json_file)
-        book_slugs_by_uuid = {
-            elem["uuid"]: elem["slug"] for elem in json_data
-        }
-        book_slug = book_slugs_by_uuid[collection_uuid]
+    # Parse slug from JSON file if provided, else from the binder
+    if book_slugs_file:
+        with open(book_slugs_file, "r") as json_file:
+            json_data = json.load(json_file)
+            book_slugs_by_uuid = {
+                elem["uuid"]: elem["slug"] for elem in json_data
+            }
+            book_slug = book_slugs_by_uuid[collection_uuid]
+    else:
+        book_slug = metadata.slug
 
     tree = utils.model_to_tree(binder)
+
+    # Use any existing book metadata to determine whether to fallback to
+    # values from the XHTML metadata
+    book_metadata = baked_metadata.get(binder.ident_hash, {})
 
     baked_book_json = {
         "title": metadata.title,
         "revised": metadata.revised,
         "tree": tree,
-        "slug": book_slug
+        "slug": book_slug,
+        "id": book_metadata.get("id") or binder.id,
+        "version": book_metadata.get("version") or metadata.version,
+        "license": book_metadata.get("license") or {
+            "url": metadata.license_url,
+            "name": metadata.license_text
+        }
     }
 
     # If there is existing book metadata provided, update with data above

--- a/bakery/src/scripts/bake_book_metadata.py
+++ b/bakery/src/scripts/bake_book_metadata.py
@@ -17,17 +17,6 @@ def main():
         metadata = DocumentMetadataParser(html)
         binder = reconstitute(baked_xhtml)
 
-    if book_slugs_file:
-        required_metadata = ('title', 'revised')
-    else:
-        required_metadata = ('title', 'revised', 'slug')
-
-    for required_data in required_metadata:
-        if getattr(metadata, required_data) is None:
-            raise ValueError(
-                "A value for '{}' could not be found.".format(required_data)
-            )
-
     with open(raw_metadata_file, "r") as raw_json:
         baked_metadata = json.load(raw_json)
 

--- a/bakery/src/scripts/bake_book_metadata_group.sh
+++ b/bakery/src/scripts/bake_book_metadata_group.sh
@@ -10,20 +10,7 @@ for collection in "${BAKED_INPUT}/"*.baked.xhtml; do
             continue
         fi
     fi
-    book_metadata="${FETCHED_INPUT}/raw/metadata/$slug_name.metadata.json"
-    book_uuid=$(jq -r '.id' "$book_metadata")
-    book_version=$(jq -r '.version' "$book_metadata")
-    book_legacy_id=$(jq -r '.legacy_id' "$book_metadata")
-    book_legacy_version=$(jq -r '.legacy_version' "$book_metadata")
-    book_ident_hash="$book_uuid@$book_version"
-    book_license=$(jq -r '.license' "$book_metadata")
-    book_slugs_file="${FETCHED_INPUT}/book-slugs.json"
 
-    jq --arg ident_hash "$book_ident_hash" --arg uuid "$book_uuid" --arg version "$book_version" --argjson license "$book_license" \
-        --arg legacy_id "$book_legacy_id" --arg legacy_version "$book_legacy_version" \
-        '. + {($ident_hash): {id: $uuid, version: $version, license: $license, legacy_id: $legacy_id, legacy_version: $legacy_version}}' \
-        "${ASSEMBLED_META_INPUT}/$slug_name.assembled-metadata.json" \
-        > "/tmp/$slug_name.baked-input-metadata.json"
-    bake-meta "/tmp/$slug_name.baked-input-metadata.json" "${BAKED_INPUT}/$slug_name.baked.xhtml" "$book_uuid" "$book_slugs_file" "${BAKED_META_OUTPUT}/$slug_name.baked-metadata.json"
+    bake-meta "${ASSEMBLED_META_INPUT}/$slug_name.assembled-metadata.json" "${BAKED_INPUT}/$slug_name.baked.xhtml" "" "" "${BAKED_META_OUTPUT}/$slug_name.baked-metadata.json"
 done
 shopt -u globstar nullglob

--- a/bakery/src/scripts/book-schema-git.json
+++ b/bakery/src/scripts/book-schema-git.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "book-schema",
+  "description": "Schema for JSON book data",
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string",
+      "description": "The title of the book"
+    },
+    "id": {
+      "type": "string",
+      "description": "The UUID ID for a book",
+      "pattern": "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}$"
+    },
+    "version": {
+      "type": "string",
+      "description": "The book version string"
+    },
+    "revised": {
+      "type": "string",
+      "description": "The revision date of this version of the book"
+    },
+    "license": {
+      "type": "object",
+      "description": "License information for book",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "URL of license such as http://creativecommons.org/licenses/by-nc-sa/4.0/"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of license as string"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["url", "name"]
+    },
+    "slug": {
+      "type": "string",
+      "description": "The slug for the book"
+    },
+    "tree": {
+      "type": "object",
+      "description": "The tree data for the book"
+    },
+    "content": {
+      "type": "string",
+      "description": "The XHTML TOC content for the book"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["title", "id", "version", "revised", "license", "slug",
+               "tree", "content"]
+}

--- a/bakery/src/scripts/fetch_book_group.sh
+++ b/bakery/src/scripts/fetch_book_group.sh
@@ -19,7 +19,6 @@ fi
 fetch-update-meta "${CONTENT_OUTPUT}/raw/.git" "${CONTENT_OUTPUT}/raw/modules" "${CONTENT_OUTPUT}/raw/collections" "$reference"
 rm -rf "${CONTENT_OUTPUT}/raw/.git"
 rm -rf "$creds_dir"
-wget "${BOOK_SLUGS_URL}" -O "${CONTENT_OUTPUT}/book-slugs.json"
 
 fetch-map-resources "${CONTENT_OUTPUT}/raw/modules" "${CONTENT_OUTPUT}/raw/media" . "${UNUSED_RESOURCE_OUTPUT}"
 # Either the media is in resources or unused-resources, this folder should be empty (-d will fail otherwise)

--- a/bakery/src/scripts/fetch_book_group.sh
+++ b/bakery/src/scripts/fetch_book_group.sh
@@ -16,7 +16,7 @@ if [[ ! -f "${CONTENT_OUTPUT}/raw/collections/$(cat "${BOOK_INPUT}/slug").collec
     echo "No matching book for slug in this repo"
     exit 1
 fi
-fetch-update-meta "${CONTENT_OUTPUT}/raw/.git" "${CONTENT_OUTPUT}/raw/modules"
+fetch-update-meta "${CONTENT_OUTPUT}/raw/.git" "${CONTENT_OUTPUT}/raw/modules" "${CONTENT_OUTPUT}/raw/collections" "$reference"
 rm -rf "${CONTENT_OUTPUT}/raw/.git"
 rm -rf "$creds_dir"
 wget "${BOOK_SLUGS_URL}" -O "${CONTENT_OUTPUT}/book-slugs.json"

--- a/bakery/src/scripts/fetch_update_metadata.py
+++ b/bakery/src/scripts/fetch_update_metadata.py
@@ -8,12 +8,15 @@ from lxml import etree
 
 NS_MDML = "http://cnx.rice.edu/mdml"
 NS_CNXML = "http://cnx.rice.edu/cnxml"
+NS_COLLXML = "http://cnx.rice.edu/collxml"
+GIT_SHA_PREFIX_LEN = 7
 
 
-def add_metadata_entries(cnxml_doc, new_metadata):
-    metadata = cnxml_doc.xpath(
+def add_metadata_entries(xml_doc, new_metadata, md_namespace):
+    """Insert metadata entries from dictionairy into document"""
+    metadata = xml_doc.xpath(
         "//x:metadata",
-        namespaces={"x": NS_CNXML}
+        namespaces={"x": md_namespace}
     )[0]
 
     for tag, value in new_metadata.items():
@@ -23,21 +26,54 @@ def add_metadata_entries(cnxml_doc, new_metadata):
         metadata.append(element)
 
 
+def determine_book_version(reference, repo, commit):
+    """Determine the book version string given a reference, a git repo, and
+    a target a commit"""
+    # We want to check if the provided reference is a tag that matches the
+    # target commit. Otherwise, we will either select a unique associated tag,
+    # or if all else fails fallback to the first few characters of the commit
+    # sha
+    matching_tags = [
+        ref.shorthand for ref in repo.references.objects
+        if ref.name.startswith("refs/tags") and ref.target == commit.id
+    ]
+
+    if reference in matching_tags:
+        # The provided reference matches a tag for the commit
+        return reference
+
+    # If the provided reference isn't a matching tag, but a single matching tag
+    # was identified, return it.
+    if len(matching_tags) == 1:
+        return matching_tags[0]
+
+    # Fallback to returning a version based on commit sha in all other cases
+    return str(commit.id)[0:GIT_SHA_PREFIX_LEN]
+
+
 def main():
     git_repo = Path(sys.argv[1]).resolve(strict=True)
     modules_dir = Path(sys.argv[2]).resolve(strict=True)
+    collections_dir = Path(sys.argv[3]).resolve(strict=True)
+    reference = sys.argv[4]
     repo = Repository(git_repo)
 
     # For the time being, we're going to parse the timestamp of the HEAD
     # commit and use that as the revised time for all module pages.
+    commit = repo.revparse_single('HEAD')
     revised_time = datetime.fromtimestamp(
-        repo.revparse_single('HEAD').commit_time,
+        commit.commit_time,
         timezone.utc
     ).isoformat()
+    book_version = determine_book_version(reference, repo, commit)
 
     module_files = [
         cf.resolve(strict=True) for cf in modules_dir.glob("**/*")
         if cf.is_file() and cf.name == "index.cnxml"
+    ]
+
+    collection_files = [
+        cf.resolve(strict=True) for cf in collections_dir.glob("*.xml")
     ]
 
     for module_file in module_files:
@@ -45,10 +81,21 @@ def main():
         new_metadata = {
             "revised": revised_time
         }
-        add_metadata_entries(cnxml_doc, new_metadata)
+        add_metadata_entries(cnxml_doc, new_metadata, NS_CNXML)
 
         with open(module_file, "wb") as f:
             cnxml_doc.write(f, encoding="utf-8", xml_declaration=False)
+
+    for collection_file in collection_files:
+        collection_doc = etree.parse(str(collection_file))
+        new_metadata = {
+            "revised": revised_time,
+            "version": book_version
+        }
+        add_metadata_entries(collection_doc, new_metadata, NS_COLLXML)
+
+        with open(collection_file, "wb") as f:
+            collection_doc.write(f, encoding="utf-8", xml_declaration=False)
 
 
 if __name__ == "__main__":

--- a/bakery/src/scripts/jsonify_single.sh
+++ b/bakery/src/scripts/jsonify_single.sh
@@ -3,7 +3,7 @@
 exec 2> >(tee "${JSONIFIED_OUTPUT}"/stderr >&2)
 
 jsonify "${DISASSEMBLED_INPUT}" "${JSONIFIED_OUTPUT}"
-jsonschema -i "${JSONIFIED_OUTPUT}/$(cat "${BOOK_INPUT}/slug").toc.json" /code/scripts/book-schema.json
+jsonschema -i "${JSONIFIED_OUTPUT}/$(cat "${BOOK_INPUT}/slug").toc.json" /code/scripts/book-schema-git.json
 
 for jsonfile in "${JSONIFIED_OUTPUT}/"*@*.json; do
     jsonschema -i "$jsonfile" /code/scripts/page-schema.json

--- a/bakery/src/scripts/link_single.py
+++ b/bakery/src/scripts/link_single.py
@@ -6,7 +6,6 @@ uuids from the target module and corresponding canonical book       .
 import sys
 import re
 import json
-import os
 from pathlib import Path
 
 from lxml import etree
@@ -21,33 +20,43 @@ def load_baked_collection(input_dir, book_slug):
     return etree.parse(baked_collection)
 
 
-def create_canonical_map(input_dir):
-    """Create a canonical book map from baked collections"""
+def parse_collection_binders(input_dir):
+    """Create a list of binders from book collections"""
     baked_collections = Path(input_dir).glob("*.baked.xhtml")
-    canonical_map = {}
+    binders = []
 
     for baked_collection in baked_collections:
         with open(baked_collection, "r") as baked_file:
             binder = reconstitute(baked_file)
-            for doc in flatten_to_documents(binder):
-                canonical_map[doc.id] = doc.metadata['canonical_book_uuid']
+            binders.append(binder)
+
+    return binders
+
+
+def create_canonical_map(binders):
+    """Create a canonical book map from a set of binders"""
+    canonical_map = {}
+
+    for binder in binders:
+        for doc in flatten_to_documents(binder):
+            canonical_map[doc.id] = doc.metadata['canonical_book_uuid']
 
     return canonical_map
 
 
-def create_slug_map(input_dir):
-    """Create a slug:uuid map from baked metadata files"""
-    baked_metadata_files = Path(input_dir).glob("*.baked-metadata.json")
-    slug_map = {}
+def parse_book_metadata(binders, input_dir):
+    """Create a list of book metadata for a set of binders using collection
+    metadata files"""
+    book_metadata = []
 
-    for baked_metadata in baked_metadata_files:
-        with open(baked_metadata, "r") as metadata_file:
+    for binder in binders:
+        slug = binder.metadata["slug"]
+        baked_metadata_file = Path(input_dir) / f"{slug}.baked-metadata.json"
+        with open(baked_metadata_file, "r") as metadata_file:
             metadata = json.load(metadata_file)
-            for entry in metadata.values():
-                if entry.get("slug"):
-                    slug_map[entry["slug"]] = entry["id"]
+            book_metadata.append(metadata[binder.ident_hash])
 
-    return slug_map
+    return book_metadata
 
 
 def get_target_uuid(link):
@@ -59,24 +68,8 @@ def get_target_uuid(link):
         parsed).group(1)
 
 
-def gen_page_slug_resolver(baked_meta_dir, slug_map):
+def gen_page_slug_resolver(baked_meta_dir, book_tree_by_uuid):
     """Generate a page slug resolver function"""
-
-    book_tree_by_uuid = {}
-    for root, _, files in os.walk(baked_meta_dir):
-        for filename in files:
-            if 'metadata' not in filename:
-                continue
-            slug = filename.split('.')[0]
-            with open(Path(root) / filename, 'r') as f:
-                baked_meta = json.load(f)
-            uuid = slug_map[slug]
-            # FIXME: Looking for tree like this pretty brittle, but it saves us from needing to
-            # now the book version and helps us when bugs occur in the cnx-archive-uri attrribute.
-            # Something like reconstituting the baked file w/`baked_metadata.get(binder.ident_hash)`
-            # will fare better
-            book_tree_by_uuid[uuid] = next(
-                v for k, v in baked_meta.items() if 'tree' in v)['tree']
 
     def _get_page_slug(book_uuid, page_uuid):
         """Get page slug from book"""
@@ -138,10 +131,19 @@ def save_linked_collection(output_path, doc):
 def transform_links(
         baked_content_dir, baked_meta_dir, source_book_slug, output_path):
     doc = load_baked_collection(baked_content_dir, source_book_slug)
-    canonical_map = create_canonical_map(baked_content_dir)
-    slug_map = create_slug_map(baked_meta_dir)
-    source_book_uuid = slug_map[source_book_slug]
-    page_slug_resolver = gen_page_slug_resolver(baked_meta_dir, slug_map)
+    binders = parse_collection_binders(baked_content_dir)
+    canonical_map = create_canonical_map(binders)
+    book_metadata = parse_book_metadata(binders, baked_meta_dir)
+
+    uuid_by_slug = {entry["slug"]: entry["id"] for entry in book_metadata}
+    book_tree_by_uuid = {
+        entry["id"]: entry["tree"] for entry in book_metadata
+    }
+    source_book_uuid = uuid_by_slug[source_book_slug]
+    page_slug_resolver = gen_page_slug_resolver(
+        baked_meta_dir,
+        book_tree_by_uuid
+    )
 
     # look up uuids for external module links
     for node in doc.xpath(
@@ -153,7 +155,7 @@ def transform_links(
         target_module_uuid = get_target_uuid(link)
         canonical_book_uuid = canonical_map[target_module_uuid]
         canonical_book_slug = next(
-            (slug for slug, uuid in slug_map.items()
+            (slug for slug, uuid in uuid_by_slug.items()
              if uuid == canonical_book_uuid))
 
         page_slug = page_slug_resolver(canonical_book_uuid, target_module_uuid)

--- a/bakery/src/scripts/link_single.sh
+++ b/bakery/src/scripts/link_single.sh
@@ -4,5 +4,5 @@ exec 2> >(tee "$LINKED_OUTPUT/stderr" >&2)
 if [[ -n "${TARGET_BOOK}" ]]; then
     cp "${BAKED_INPUT}/${TARGET_BOOK}.baked.xhtml" "${LINKED_OUTPUT}/${TARGET_BOOK}.linked.xhtml"
 else
-    link-single "$BAKED_INPUT" "$BAKED_META_INPUT" "$(cat "${BOOK_INPUT}"/slug)" "$FETCHED_INPUT/book-slugs.json" "$LINKED_OUTPUT/$(cat "$BOOK_INPUT"/slug).linked.xhtml"
+    link-single "$BAKED_INPUT" "$BAKED_META_INPUT" "$(cat "${BOOK_INPUT}"/slug)" "$LINKED_OUTPUT/$(cat "$BOOK_INPUT"/slug).linked.xhtml"
 fi

--- a/bakery/src/scripts/requirements.txt
+++ b/bakery/src/scripts/requirements.txt
@@ -1,4 +1,4 @@
-cnx-epub==0.26.1
+cnx-epub==0.26.2
 cnx-common==1.3.6
 cnx-easybake==1.2.7
 awscli==1.18.48

--- a/bakery/src/tasks/fetch-book-group.js
+++ b/bakery/src/tasks/fetch-book-group.js
@@ -12,7 +12,6 @@ const task = (taskArgs) => {
   const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })
 
   const bookInput = 'book'
-  const bookSlugsUrl = 'https://raw.githubusercontent.com/openstax/content-manager-approved-books/master/book-slugs.json'
   const contentOutput = 'fetched-book-group'
   const resourceOutput = 'resources'
   const unusedResourceOutput = 'unused-resources'
@@ -36,7 +35,6 @@ const task = (taskArgs) => {
         BOOK_INPUT: bookInput,
         GH_SECRET_CREDS: githubSecretCreds,
         CONTENT_OUTPUT: contentOutput,
-        BOOK_SLUGS_URL: bookSlugsUrl,
         UNUSED_RESOURCE_OUTPUT: unusedResourceOutput
       },
       run: {

--- a/bakery/src/tests/data/collection.assembled-metadata.json
+++ b/bakery/src/tests/data/collection.assembled-metadata.json
@@ -6,6 +6,10 @@
         "abstract": "Explain the difference between a model and a theory"
     },
     "00000000-0000-0000-0000-000000000000@0.0": {
+        "id": "injected_id",
+        "version": "injected_version",
+        "legacy_id": "injected_legacy_id",
+        "legacy_version": "injected_legacy_version",
         "license": {
             "url": "http://creativecommons.org/licenses/by-nc-sa/4.0/",
             "code": "by-nc-sa",

--- a/bakery/src/tests/data/collection.baked-single.xhtml
+++ b/bakery/src/tests/data/collection.baked-single.xhtml
@@ -1,0 +1,68 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:m="http://www.w3.org/1998/Math/MathML">
+
+<head itemscope="itemscope" itemtype="http://schema.org/Book">
+
+  <title>College Physics</title>
+
+  <!-- These are for discoverability of accessible content. -->
+  <meta itemprop="accessibilityFeature" content="MathML"/>
+  <meta itemprop="accessibilityFeature" content="LaTeX"/>
+  <meta itemprop="accessibilityFeature" content="alternativeText"/>
+  <meta itemprop="accessibilityFeature" content="captions"/>
+  <meta itemprop="accessibilityFeature" content="structuredNavigation"/>
+
+  <meta itemprop="dateModified" content="2019-08-30T16:35:37.569966-05:00"/>
+</head>
+
+<body itemscope="itemscope" itemtype="http://schema.org/Book">
+  <div data-type="metadata" style="display: none;">
+    <h1 data-type="document-title" itemprop="name">College Physics</h1>
+    <span data-type="revised" data-value="2019-08-30T16:35:37.569966-05:00"></span>
+    <span data-type="slug" data-value="physics"></span>
+    <span data-type="cnx-archive-uri" data-value="c7795d04-cfca-4ec6-a30f-f48d06336635@1.2.3"></span>
+    <div class="permissions">
+      <p class="license">
+        Licensed:
+        <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC BY</a>
+      </p>
+    </div>
+  </div>
+  <nav id="toc"><h1 class="os-toc-title">Contents</h1><ol><li cnx-archive-uri="" cnx-archive-shortid="" class="os-toc-chapter"><a href="#chapTitle1"><span class="os-number">1</span><span class="os-divider"> </span><span data-type="" itemprop="" class="os-text">Introduction: The Nature of Science and Physics</span></a><ol class="os-chapter"><li cnx-archive-uri="m42119" cnx-archive-shortid="" class="os-toc-chapter-page"><a href="#m42119"><span data-type="" itemprop="" class="os-text">Introduction to Science and the Realm of Physics, Physical Quantities, and Units</span></a></li><li cnx-archive-uri="m42092" cnx-archive-shortid="" class="os-toc-chapter-page"><a href="#m42092"><span class="os-number">1.1</span><span class="os-divider"> </span><span data-type="" itemprop="" class="os-text">Physics: An Introduction</span></a></li></ol></li></ol></nav>
+  <div data-type="chapter">
+    <div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Introduction: The Nature of Science and Physics</h1>
+      <span data-type="binding" data-value="translucent"></span>
+    </div>
+    <h1 data-type="document-title" id="chapTitle1"><span class="os-number">1</span><span class="os-divider"> </span><span data-type="" itemprop="" class="os-text">Introduction: The Nature of Science and Physics</span></h1>
+    <div data-type="page" id="m42119" class="introduction" data-cnxml-to-html-ver="1.7.3">
+      <div data-type="metadata" style="display: none;">
+        <h1 data-type="document-title" itemprop="name">Introduction to Science and the Realm of Physics, Physical Quantities, and Units</h1>
+        <span data-type="cnx-archive-uri" data-value="m42119@1.6"></span>
+        <p class="license">
+          Licensed:
+          <a href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC BY</a>
+        </p>
+      </div>
+
+
+    <div class="intro-body"><div class="os-chapter-outline"><h3 class="os-title">Chapter Outline</h3><div class="os-chapter-objective"><a class="os-chapter-objective" href="#auto_m42092_58161"><span class="os-number">1.1</span><span class="os-divider"> </span><span data-type="" itemprop="" class="os-text">Physics: An Introduction</span></a><div class="learning-objective"><div data-type="abstract" id="auto_m42092_18843">
+        <ul>
+          <li>Explain the difference between a principle and a law.</li>
+          <li>Explain the difference between a model and a theory.</li>
+        </ul>
+      </div></div></div></div><div class="intro-text"><h2 data-type="document-title" id="auto_m42119_34536"><span data-type="" itemprop="" class="os-text">Introduction to Science and the Realm of Physics, Physical Quantities, and Units</span></h2></div></div></div>
+    <div data-type="page" id="m42092" data-cnxml-to-html-ver="1.7.3" class="chapter-content-module">
+      <div data-type="metadata" style="display: none;">
+        <h1 data-type="document-title" itemprop="name">Physics: An Introduction</h1>
+        <span data-type="cnx-archive-uri" data-value="m42092@1.10"></span>
+        <p class="license">
+          Licensed:
+          <a href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC BY</a>
+        </p>
+      </div>
+      <h2 data-type="document-title" id="auto_m42092_58161"><span class="os-number">1.1</span><span class="os-divider"> </span><span data-type="" itemprop="" class="os-text">Physics: An Introduction</span></h2>
+
+    </div>
+  </div>
+</body>
+</html>

--- a/bakery/src/tests/test_bakery_scripts.py
+++ b/bakery/src/tests/test_bakery_scripts.py
@@ -955,16 +955,64 @@ def test_bake_book_metadata(tmp_path, mocker):
     bake_book_metadata.main()
 
     baked_metadata = json.loads(output_baked_book_metadata.read_text())
+    book_metadata = baked_metadata[book_ident_hash]
 
-    assert isinstance(baked_metadata[book_ident_hash]["tree"], dict) is True
-    assert "contents" in baked_metadata[book_ident_hash]["tree"].keys()
-    assert "license" in baked_metadata[book_ident_hash].keys()
+    assert isinstance(book_metadata["tree"], dict) is True
+    assert "contents" in book_metadata["tree"].keys()
+    assert "license" in book_metadata.keys()
     assert (
-        baked_metadata[book_ident_hash]["revised"]
+        book_metadata["revised"]
         == "2019-08-30T16:35:37.569966-05:00"
     )
-    assert "College Physics" in baked_metadata[book_ident_hash]["title"]
-    assert baked_metadata[book_ident_hash]["slug"] == "test-book-slug"
+    assert "College Physics" in book_metadata["title"]
+    assert book_metadata["slug"] == "test-book-slug"
+    assert book_metadata["id"] == "injected_id"
+    assert book_metadata["version"] == "injected_version"
+    assert book_metadata["legacy_id"] == "injected_legacy_id"
+    assert book_metadata["legacy_version"] == "injected_legacy_version"
+
+
+def test_bake_book_metadata_git(tmp_path, mocker):
+    """Test bake_book_metadata script with git storage inputs"""
+    input_baked_xhtml = os.path.join(
+        TEST_DATA_DIR, "collection.baked-single.xhtml"
+    )
+    input_raw_metadata = tmp_path / "collection.assembled-metadata.json"
+    output_baked_book_metadata = tmp_path / "collection.toc-metadata.json"
+
+    input_raw_metadata.write_text(json.dumps({}))
+
+    with open(input_baked_xhtml, "r") as baked_xhtml:
+        binder = reconstitute(baked_xhtml)
+        book_ident_hash = binder.ident_hash
+
+    mocker.patch(
+        "sys.argv",
+        [
+            "",
+            input_raw_metadata,
+            input_baked_xhtml,
+            "",
+            "",
+            output_baked_book_metadata,
+        ],
+    )
+    bake_book_metadata.main()
+
+    baked_metadata = json.loads(output_baked_book_metadata.read_text())
+    book_metadata = baked_metadata[book_ident_hash]
+
+    assert isinstance(book_metadata["tree"], dict) is True
+    assert "contents" in book_metadata["tree"].keys()
+    assert "license" in book_metadata.keys()
+    assert (
+        book_metadata["revised"]
+        == "2019-08-30T16:35:37.569966-05:00"
+    )
+    assert "College Physics" in book_metadata["title"]
+    assert book_metadata["slug"] == "physics"
+    assert book_metadata["id"] == "c7795d04-cfca-4ec6-a30f-f48d06336635"
+    assert book_metadata["version"] == "1.2.3"
 
 
 def test_check_feed(tmp_path, mocker):

--- a/bakery/src/tests/test_bakery_scripts.py
+++ b/bakery/src/tests/test_bakery_scripts.py
@@ -2335,6 +2335,9 @@ def test_link_single(tmp_path, mocker):
         <body itemscope="itemscope" itemtype="http://schema.org/Book">
         <div data-type="metadata" style="display: none;">
         <h1 data-type="document-title" itemprop="name">Book1</h1>
+        <span data-type="slug" data-value="book1"></span>
+        <span data-type="cnx-archive-uri"
+            data-value="1ba7e813-2d8a-4b73-87a1-876cfb5e7b58@version"></span>
         </div>
         <nav id="toc">
         <ol>
@@ -2384,6 +2387,9 @@ def test_link_single(tmp_path, mocker):
         <body itemscope="itemscope" itemtype="http://schema.org/Book">
         <div data-type="metadata" style="display: none;">
         <h1 data-type="document-title" itemprop="name">Book2</h1>
+        <span data-type="slug" data-value="book2"></span>
+        <span data-type="cnx-archive-uri"
+            data-value="3c321f43-1da5-4c7b-91d1-abca2dd8ab8f@version"></span>
         </div>
         <nav id="toc">
         <ol>

--- a/bakery/src/tests/test_bakery_scripts.py
+++ b/bakery/src/tests/test_bakery_scripts.py
@@ -2327,20 +2327,8 @@ def test_link_single(tmp_path, mocker):
     baked_dir.mkdir()
     baked_meta_dir = tmp_path / "baked-book-metadata-group"
     baked_meta_dir.mkdir()
-    book_slugs = tmp_path / "book-slugs.json"
     source_book_slug = "book1"
     linked_xhtml = tmp_path / "book1.linked.xhtml"
-
-    book_slugs.write_text(json.dumps([
-        {
-            "uuid": "1ba7e813-2d8a-4b73-87a1-876cfb5e7b58",
-            "slug": "book1"
-        },
-        {
-            "uuid": "3c321f43-1da5-4c7b-91d1-abca2dd8ab8f",
-            "slug": "book2"
-        }
-    ]))
 
     book1_baked_content = """
         <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
@@ -2372,8 +2360,10 @@ def test_link_single(tmp_path, mocker):
     """
     book1_baked_meta_content = {
         "1ba7e813-2d8a-4b73-87a1-876cfb5e7b58@version": {
+            "id": "1ba7e813-2d8a-4b73-87a1-876cfb5e7b58",
+            "slug": "book1",
             "tree": {
-                "id": "1ba7e813-2d8a-4b73-87a1-876cfb5e7b58",
+                "id": "1ba7e813-2d8a-4b73-87a1-876cfb5e7b58@version",
                 "slug": "book1",
                 "contents": [
                     {
@@ -2422,8 +2412,10 @@ def test_link_single(tmp_path, mocker):
     """
     book2_baked_meta_content = {
         "3c321f43-1da5-4c7b-91d1-abca2dd8ab8f@version": {
+            "id": "3c321f43-1da5-4c7b-91d1-abca2dd8ab8f",
+            "slug": "book2",
             "tree": {
-                "id": "3c321f43-1da5-4c7b-91d1-abca2dd8ab8f",
+                "id": "3c321f43-1da5-4c7b-91d1-abca2dd8ab8f@version",
                 "slug": "book2",
                 "contents": [
                     {
@@ -2445,8 +2437,7 @@ def test_link_single(tmp_path, mocker):
 
     mocker.patch(
         "sys.argv",
-        ["", baked_dir, baked_meta_dir, source_book_slug, book_slugs,
-         linked_xhtml]
+        ["", baked_dir, baked_meta_dir, source_book_slug, linked_xhtml]
     )
     link_single.main()
 


### PR DESCRIPTION
This PR includes the following changes to bakery tasks for the git pipeline:

* `fetch-group`
    * Injects `revised` and `version` data into book collection file.
    * No longer downloads `book-slugs.json`
* `assemble-group`
    * Remove use of book `metadata.json`
* `bake-meta-group`
    * Remove use of book `metadata.json` and `book-slugs.json` (this includes no longer injecting metadata in the task bash script)
    * Updating python script to be compatible with both archive and git flows
* `link-single`
    * Remove use of `book-slugs.json` and instead use data in the group baked files
    * Some minor refactoring of the Python script
* `jsonify-single`
    * Add / use a dedicated book schema