### PR TITLE
Update fetch-map-resources for relative image paths

### DIFF
--- a/bakery/src/tests/test_bakery_scripts.py
+++ b/bakery/src/tests/test_bakery_scripts.py
@@ -2141,9 +2141,9 @@ def test_fetch_map_resources(tmp_path, mocker):
     module_00001_content = (
         '<document xmlns="http://cnx.rice.edu/cnxml">'
         '<content>'
-        '<image src="image_src.svg"/>'
-        '<image src="image_missing.jpg"/>'
-        '<image src="image_src.svg"/>'
+        '<image src="../../media/image_src.svg"/>'
+        '<image src="../../media/image_missing.jpg"/>'
+        '<image src="../../media/image_src.svg"/>'
         '</content>'
         '</document>'
     )
@@ -2172,7 +2172,7 @@ def test_fetch_map_resources(tmp_path, mocker):
         f'<document xmlns="http://cnx.rice.edu/cnxml">'
         f'<content>'
         f'<image src="../resources/{image_src_sha1_expected}"/>'
-        f'<image src="image_missing.jpg"/>'
+        f'<image src="../../media/image_missing.jpg"/>'
         f'<image src="../resources/{image_src_sha1_expected}"/>'
         f'</content>'
         f'</document>'


### PR DESCRIPTION
This change modifies the script to use the relative URL in the CNXML
image src to locate used image files instead of assuming all images
to be located in a given input directory. It does, however, leave the
input parameter so we can collect unused resources. This aspect can be
revisited in the future as needed, but doesn't impact functionality in
terms of supported relative image paths.