### PR TITLE
Use canonical.json to override module canonical book metadata

### DIFF
--- a/bakery/src/scripts/fetch_book_group.sh
+++ b/bakery/src/scripts/fetch_book_group.sh
@@ -19,7 +19,7 @@ if [[ ! -f "${CONTENT_OUTPUT}/raw/collections/$(cat "${BOOK_INPUT}/slug").collec
     sleep 1
     exit 1
 fi
-fetch-update-meta "${CONTENT_OUTPUT}/raw/.git" "${CONTENT_OUTPUT}/raw/modules" "${CONTENT_OUTPUT}/raw/collections" "$reference"
+fetch-update-meta "${CONTENT_OUTPUT}/raw/.git" "${CONTENT_OUTPUT}/raw/modules" "${CONTENT_OUTPUT}/raw/collections" "$reference" "${CONTENT_OUTPUT}/raw/canonical.json"
 rm -rf "${CONTENT_OUTPUT}/raw/.git"
 rm -rf "$creds_dir"
 

--- a/bakery/src/scripts/fetch_update_metadata.py
+++ b/bakery/src/scripts/fetch_update_metadata.py
@@ -2,7 +2,6 @@
 
 import sys
 from pathlib import Path
-from glob import glob
 from pygit2 import Repository
 from datetime import datetime, timezone
 from lxml import etree
@@ -14,7 +13,7 @@ NS_COLLXML = "http://cnx.rice.edu/collxml"
 GIT_SHA_PREFIX_LEN = 7
 
 
-def  remove_metadata_entries(xml_doc, old_metadata, md_namespace):
+def remove_metadata_entries(xml_doc, old_metadata, md_namespace):
     metadata = xml_doc.xpath(
         "//x:metadata",
         namespaces={"x": md_namespace}
@@ -22,10 +21,12 @@ def  remove_metadata_entries(xml_doc, old_metadata, md_namespace):
 
     for tag in old_metadata:
         element = metadata.xpath(
-            f"/md:{tag}",
+            f"./md:{tag}",
             namespaces={"md": NS_MDML}
-        )[0]
-        metadata.remove(element)
+        )
+        if element:
+            metadata.remove(element[0])
+
 
 
 def add_metadata_entries(xml_doc, new_metadata, md_namespace):
@@ -80,10 +81,10 @@ def main():
     canonical_mapping = {}
 
     for bookslug in reversed(canonical_list):
-        collection = collection_dir/f'{bookslug}.collection.xml'
+        collection = collections_dir / f'{bookslug}.collection.xml'
         col_tree = etree.parse(str(collection))
-        col_modules = col_tree.xpath("//col:module/@document", namespaces={"col" : NS_COLLXML})
-        col_uuid = col_tree.xpath("//md:uuid", namespaces={"md" : NS_MDML})
+        col_modules = col_tree.xpath("//col:module/@document", namespaces={"col": NS_COLLXML})
+        col_uuid = col_tree.xpath("//md:uuid", namespaces={"md": NS_MDML})[0].text
         for module in col_modules:
             canonical_mapping[module] = col_uuid
 

--- a/bakery/src/scripts/fetch_update_metadata.py
+++ b/bakery/src/scripts/fetch_update_metadata.py
@@ -28,7 +28,6 @@ def remove_metadata_entries(xml_doc, old_metadata, md_namespace):
             metadata.remove(element[0])
 
 
-
 def add_metadata_entries(xml_doc, new_metadata, md_namespace):
     """Insert metadata entries from dictionairy into document"""
     metadata = xml_doc.xpath(

--- a/bakery/src/tests/test_bakery_scripts.py
+++ b/bakery/src/tests/test_bakery_scripts.py
@@ -2199,8 +2199,8 @@ def test_fetch_update_metadata(tmp_path, mocker):
 
     coll_file = collections_dir / "test.collection.xml"
     coll_content = (
-        '<col:collection xmlns:col="http://cnx.rice.edu/collxml" xmlns:md="http://cnx.rice.edu/mdml">'
-        '<col:metadata mdml-version="0.5">'
+        '<col:collection xmlns:col="http://cnx.rice.edu/collxml">'
+        '<col:metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">'
         '<md:uuid>some-random-uuid</md:uuid>'
         '</col:metadata>'
         '<col:module document="m00001" />'
@@ -2251,8 +2251,8 @@ def test_fetch_update_metadata(tmp_path, mocker):
 
     tree = etree.parse(str(coll_file))
     expected = (
-        '<col:collection xmlns:col="http://cnx.rice.edu/collxml" xmlns:md="http://cnx.rice.edu/mdml">'
-        '<col:metadata mdml-version="0.5">'
+        '<col:collection xmlns:col="http://cnx.rice.edu/collxml">'
+        '<col:metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">'
         '<md:uuid>some-random-uuid</md:uuid>'
         '<md:revised>2021-01-13T01:13:00+00:00</md:revised>\n'
         '<md:version>somegittag</md:version>\n'
@@ -2279,7 +2279,7 @@ def test_fetch_update_metadata_canonical_ordering(tmp_path, mocker):
 
     coll_file_0 = collections_dir / "test0.collection.xml"
     coll_content_0 = (
-        '<col:collection xmlns:col="http://cnx.rice.edu/collxml" xmlns:md="http://cnx.rice.edu/mdml">'
+        '<col:collection xmlns:col="http://cnx.rice.edu/collxml">'
         '<col:metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">'
         '<md:uuid>some-random-uuid-0</md:uuid>'
         '</col:metadata>'
@@ -2291,7 +2291,7 @@ def test_fetch_update_metadata_canonical_ordering(tmp_path, mocker):
 
     coll_file_1 = collections_dir / "test1.collection.xml"
     coll_content_1 = (
-        '<col:collection xmlns:col="http://cnx.rice.edu/collxml" xmlns:md="http://cnx.rice.edu/mdml">'
+        '<col:collection xmlns:col="http://cnx.rice.edu/collxml">'
         '<col:metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">'
         '<md:uuid>some-random-uuid-1</md:uuid>'
         '</col:metadata>'

--- a/bakery/src/tests/test_bakery_scripts.py
+++ b/bakery/src/tests/test_bakery_scripts.py
@@ -2185,16 +2185,32 @@ def test_fetch_map_resources(tmp_path, mocker):
 
 def test_fetch_update_metadata(tmp_path, mocker):
     """Test fetch-update-metadata script"""
-    book_dir = tmp_path / "book_slug/fetched-book-group/raw/modules"
-    collections_dir = tmp_path / "book_slug/fetched-book-group/raw/collections"
+    book_dir = tmp_path / "book_slug/fetched-book-group/raw/"
+    modules_dir = book_dir / "modules"
+    collections_dir = book_dir / "collections"
+    canonical_file = book_dir / "canonical.json"
     repo_path = tmp_path / ".repo"
+    modules_dir.mkdir(parents=True)
     collections_dir.mkdir(parents=True)
-    book_dir.mkdir(parents=True)
     repo_path.mkdir()
 
-    module_0001_dir = book_dir / "m00001"
-    module_0001_dir.mkdir()
-    module_00001 = book_dir / "m00001/index.cnxml"
+    canonical_content = json.dumps(['test'])
+    canonical_file.write_text(canonical_content)
+
+    coll_file = collections_dir / "test.collection.xml"
+    coll_content = (
+        '<col:collection xmlns:col="http://cnx.rice.edu/collxml" xmlns:md="http://cnx.rice.edu/mdml">'
+        '<col:metadata mdml-version="0.5">'
+        '<md:uuid>some-random-uuid</md:uuid>'
+        '</col:metadata>'
+        '<col:module document="m00001" />'
+        '</col:collection>'
+    )
+    coll_file.write_text(coll_content)
+
+    module_00001_dir = modules_dir / "m00001"
+    module_00001_dir.mkdir()
+    module_00001 = modules_dir / "m00001/index.cnxml"
     module_00001_content = (
         '<document xmlns="http://cnx.rice.edu/cnxml">'
         '<metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">'
@@ -2202,16 +2218,6 @@ def test_fetch_update_metadata(tmp_path, mocker):
         '</document>'
     )
     module_00001.write_text(module_00001_content)
-
-    collection_xml = collections_dir / "collection.xml"
-    collection_xml_content = (
-        '<col:collection xmlns="http://cnx.rice.edu/collxml" '
-        'xmlns:col="http://cnx.rice.edu/collxml">'
-        '<metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">'
-        '</metadata>'
-        '</col:collection>'
-    )
-    collection_xml.write_text(collection_xml_content)
 
     repo_mock = mocker.MagicMock()
     commit_mock = repo_mock().revparse_single()
@@ -2224,7 +2230,7 @@ def test_fetch_update_metadata(tmp_path, mocker):
     repo_mock().references.objects = [ref1_mock]
     mocker.patch(
         "sys.argv",
-        ["", repo_path, book_dir, collections_dir, ref1_mock.shorthand]
+        ["", repo_path, modules_dir, collections_dir, ref1_mock.shorthand, canonical_file]
     )
     mocker.patch(
         "bakery_scripts.fetch_update_metadata.Repository",
@@ -2232,27 +2238,152 @@ def test_fetch_update_metadata(tmp_path, mocker):
     )
     fetch_update_metadata.main()
 
-    # Check page updates
     tree = etree.parse(str(module_00001))
     expected = (
         '<document xmlns="http://cnx.rice.edu/cnxml">'
         '<metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">'
         '<md:revised>2021-01-13T01:13:00+00:00</md:revised>\n'
+        '<md:canonical-book-uuid>some-random-uuid</md:canonical-book-uuid>\n'
         '</metadata>'
         '</document>'
     )
     assert etree.tostring(tree, encoding="utf8") == expected.encode("utf8")
 
-    # Check book updates
-    tree = etree.parse(str(collection_xml))
+    tree = etree.parse(str(coll_file))
     expected = (
-        '<col:collection xmlns="http://cnx.rice.edu/collxml" '
-        'xmlns:col="http://cnx.rice.edu/collxml">'
-        '<metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">'
+        '<col:collection xmlns:col="http://cnx.rice.edu/collxml" xmlns:md="http://cnx.rice.edu/mdml">'
+        '<col:metadata mdml-version="0.5">'
+        '<md:uuid>some-random-uuid</md:uuid>'
         '<md:revised>2021-01-13T01:13:00+00:00</md:revised>\n'
         '<md:version>somegittag</md:version>\n'
-        '</metadata>'
+        '</col:metadata>'
+        '<col:module document="m00001"/>'
         '</col:collection>'
+    )
+    assert etree.tostring(tree, encoding="utf8") == expected.encode("utf8")
+
+
+def test_fetch_update_metadata_canonical_ordering(tmp_path, mocker):
+    """Test canonical ordering in fetch-update-metadata script"""
+    book_dir = tmp_path / "book_slug/fetched-book-group/raw/"
+    modules_dir = book_dir / "modules"
+    collections_dir = book_dir / "collections"
+    canonical_file = book_dir / "canonical.json"
+    repo_path = tmp_path / ".repo"
+    modules_dir.mkdir(parents=True)
+    collections_dir.mkdir(parents=True)
+    repo_path.mkdir()
+
+    canonical_content = json.dumps(['test0', 'test1'])
+    canonical_file.write_text(canonical_content)
+
+    coll_file_0 = collections_dir / "test0.collection.xml"
+    coll_content_0 = (
+        '<col:collection xmlns:col="http://cnx.rice.edu/collxml" xmlns:md="http://cnx.rice.edu/mdml">'
+        '<col:metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">'
+        '<md:uuid>some-random-uuid-0</md:uuid>'
+        '</col:metadata>'
+        '<col:module document="m00001" />'
+        '<col:module document="m00002" />'
+        '</col:collection>'
+    )
+    coll_file_0.write_text(coll_content_0)
+
+    coll_file_1 = collections_dir / "test1.collection.xml"
+    coll_content_1 = (
+        '<col:collection xmlns:col="http://cnx.rice.edu/collxml" xmlns:md="http://cnx.rice.edu/mdml">'
+        '<col:metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">'
+        '<md:uuid>some-random-uuid-1</md:uuid>'
+        '</col:metadata>'
+        '<col:module document="m00002" />'
+        '<col:module document="m00003" />'
+        '</col:collection>'
+    )
+    coll_file_1.write_text(coll_content_1)
+
+    module_00001_dir = modules_dir / "m00001"
+    module_00001_dir.mkdir()
+    module_00001 = modules_dir / "m00001/index.cnxml"
+    module_00001_content = (
+        '<document xmlns="http://cnx.rice.edu/cnxml">'
+        '<metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">'
+        '<md:canonical-book-uuid>garbage</md:canonical-book-uuid>'
+        '</metadata>'
+        '</document>'
+    )
+    module_00001.write_text(module_00001_content)
+
+    module_00002_dir = modules_dir / "m00002"
+    module_00002_dir.mkdir()
+    module_00002 = modules_dir / "m00002/index.cnxml"
+    module_00002_content = (
+        '<document xmlns="http://cnx.rice.edu/cnxml">'
+        '<metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">'
+        '</metadata>'
+        '</document>'
+    )
+    module_00002.write_text(module_00002_content)
+
+    module_00003_dir = modules_dir / "m00003"
+    module_00003_dir.mkdir()
+    module_00003 = modules_dir / "m00003/index.cnxml"
+    module_00003_content = (
+        '<document xmlns="http://cnx.rice.edu/cnxml">'
+        '<metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">'
+        '</metadata>'
+        '</document>'
+    )
+    module_00003.write_text(module_00003_content)
+
+    repo_mock = mocker.MagicMock()
+    commit_mock = repo_mock().revparse_single()
+    commit_mock.commit_time = 1610500380
+    commit_mock.id = "somegitsha"
+    ref1_mock = mocker.MagicMock()
+    ref1_mock.name = "refs/tags/somegittag"
+    ref1_mock.target = "somegitsha"
+    ref1_mock.shorthand = "somegittag"
+    repo_mock().references.objects = [ref1_mock]
+    mocker.patch(
+        "sys.argv",
+        ["", repo_path, modules_dir, collections_dir, ref1_mock.shorthand, canonical_file]
+    )
+    mocker.patch(
+        "bakery_scripts.fetch_update_metadata.Repository",
+        repo_mock
+    )
+    fetch_update_metadata.main()
+
+    tree = etree.parse(str(module_00001))
+    expected = (
+        '<document xmlns="http://cnx.rice.edu/cnxml">'
+        '<metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">'
+        '<md:revised>2021-01-13T01:13:00+00:00</md:revised>\n'
+        '<md:canonical-book-uuid>some-random-uuid-0</md:canonical-book-uuid>\n'
+        '</metadata>'
+        '</document>'
+    )
+    assert etree.tostring(tree, encoding="utf8") == expected.encode("utf8")
+
+    tree = etree.parse(str(module_00002))
+    expected = (
+        '<document xmlns="http://cnx.rice.edu/cnxml">'
+        '<metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">'
+        '<md:revised>2021-01-13T01:13:00+00:00</md:revised>\n'
+        '<md:canonical-book-uuid>some-random-uuid-0</md:canonical-book-uuid>\n'
+        '</metadata>'
+        '</document>'
+    )
+    assert etree.tostring(tree, encoding="utf8") == expected.encode("utf8")
+
+    tree = etree.parse(str(module_00003))
+    expected = (
+        '<document xmlns="http://cnx.rice.edu/cnxml">'
+        '<metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">'
+        '<md:revised>2021-01-13T01:13:00+00:00</md:revised>\n'
+        '<md:canonical-book-uuid>some-random-uuid-1</md:canonical-book-uuid>\n'
+        '</metadata>'
+        '</document>'
     )
     assert etree.tostring(tree, encoding="utf8") == expected.encode("utf8")
 


### PR DESCRIPTION
After merge, we can modify the sync script to remove the `canonical-book-uuid` metadata field from modules entirely before this step.