### PR TITLE
Implement Job Cancellation

### DIFF
--- a/backend/app/app/api/endpoints/jobs.py
+++ b/backend/app/app/api/endpoints/jobs.py
@@ -71,5 +71,13 @@ def update_job(
     job = jobs_service.get(db_session=db, obj_id=id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
+    # If current job status is completed state
+    if int(job.status_id) in [4,5,6]:
+        # Pipelines will try to override an completed state with
+        # assigned, processing status if unlucky
+        # Only allow updating to completed states to prevent this
+        # Don't raise HTTPException since other fields are likely valid
+        incoming_status = int(job_in.status_id)
+        job_in.status_id = incoming_status if incoming_status in [4,5,6] else job.status_id
     job = jobs_service.update(db, job, job_in)
     return job

--- a/backend/app/migrations/versions/14c3c7f3115e_add_aborted_state_seed_data.py
+++ b/backend/app/migrations/versions/14c3c7f3115e_add_aborted_state_seed_data.py
@@ -1,0 +1,43 @@
+"""add aborted state seed data
+
+Revision ID: 14c3c7f3115e
+Revises: 7744a6c02085
+Create Date: 2021-01-13 23:14:38.997558
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from datetime import datetime
+
+
+# revision identifiers, used by Alembic.
+revision = '14c3c7f3115e'
+down_revision = '7744a6c02085'
+branch_labels = None
+depends_on = None
+
+
+status_table = sa.table('status',
+                        sa.column('id', sa.Integer),
+                        sa.column('name', sa.String),
+                        sa.column('created_at', sa.DateTime),
+                        sa.column('updated_at', sa.DateTime)
+                        )
+
+
+def upgrade():
+    utcnow = datetime.utcnow()
+    bind = op.get_bind()
+
+    status_data = [{'id': 6, 'name': 'aborted', 'created_at': utcnow, 'updated_at': utcnow}]
+
+    insert = status_table.insert().values(status_data)
+
+    bind.execute(insert)
+
+
+def downgrade():
+    bind = op.get_bind()
+    delete_seed = status_table.delete().where(status_table.c.id == op.inline_literal(6) )
+    bind.execute(delete_seed)

--- a/bakery/src/pipelines/cops.js
+++ b/bakery/src/pipelines/cops.js
@@ -86,7 +86,16 @@ const pipeline = (env) => {
         steps: [
           step,
           {
-            do: [taskStatusCheck({ resource: resource, apiRoot: env.COPS_TARGET, image: imageOverrides })],
+            do: [
+              taskStatusCheck({
+                resource: resource,
+                apiRoot: env.COPS_TARGET,
+                image: imageOverrides,
+                processingStates: [Status.ASSIGNED, Status.PROCESSING],
+                completedStates: [Status.FAILED, Status.SUCCEEDED],
+                abortedStates: [Status.ABORTED]
+              })
+            ],
             on_failure: reporter(Status.ABORTED, {
               error_message: genericAbortMessage
             })

--- a/bakery/src/scripts/status_check.sh
+++ b/bakery/src/scripts/status_check.sh
@@ -8,16 +8,17 @@ while true; do
   if [[ "$status_code" = "200" ]]; then
     subsequent_failures=0
     current_job_status_id=$(jq -r '.status.id' response)
+    shopt -s extglob
     case "$current_job_status_id" in
-      2 | 3)
+      $PROCESSING_STATES)
         echo "${timestamp} | Pipeline running, no intervention needed"
         ;;
-      4 | 5)
+      $COMPLETED_STATES)
         echo "${timestamp} | Pipeline completed, no intervention needed"
         sleep 1
         exit 0
         ;;
-      6)
+      $ABORTED_STATES)
         echo "${timestamp} | Job aborted via UI, torpedoing the build"
         sleep 1
         exit 1

--- a/bakery/src/scripts/status_check.sh
+++ b/bakery/src/scripts/status_check.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+job_id=$(cat "${RESOURCE}/id")
+subsequent_failures=0
+while true; do
+  curl -w "%{http_code}" -o response "$API_ROOT/jobs/${job_id}" > status_code
+  timestamp=$(date '+%H:%M:%S')
+  status_code="$(cat status_code)"
+  if [[ "$status_code" = "200" ]]; then
+    subsequent_failures=0
+    current_job_status_id=$(jq -r '.status.id' response)
+    case "$current_job_status_id" in
+      2 | 3)
+        echo "${timestamp} | Pipeline running, no intervention needed"
+        ;;
+      4 | 5)
+        echo "${timestamp} | Pipeline completed, no intervention needed"
+        sleep 1
+        exit 0
+        ;;
+      6)
+        echo "${timestamp} | Job aborted via UI, torpedoing the build"
+        sleep 1
+        exit 1
+        ;;
+      *)
+        echo "${timestamp} | Unknown job status id ('${current_job_status_id}'), torpedoing the build"
+        sleep 1
+        exit 1
+        ;;
+    esac
+  elif [[ "$((++subsequent_failures))" -gt "2" ]]; then
+    echo "${timestamp} | Unable to check status code ('${status_code}'), torpedoing the build"
+    sleep 1
+    exit 1
+  fi
+  sleep 30
+done

--- a/bakery/src/tasks/status-check.js
+++ b/bakery/src/tasks/status-check.js
@@ -24,7 +24,7 @@ const task = (taskArgs) => {
       inputs: [{ name: resource }],
       params: {
         RESOURCE: resource,
-        API_ROOT: apiRoot,
+        API_ROOT: apiRoot
       },
       run: {
         path: '/bin/bash',

--- a/bakery/src/tasks/status-check.js
+++ b/bakery/src/tasks/status-check.js
@@ -1,0 +1,40 @@
+const { constructImageSource } = require('../task-util/task-util')
+const fs = require('fs')
+const path = require('path')
+
+const task = (taskArgs) => {
+  const { resource, apiRoot } = taskArgs
+  const imageDefault = {
+    name: 'openstax/cops-bakery-scripts',
+    tag: 'trunk'
+  }
+  const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
+  const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })
+
+  const shellScript = fs.readFileSync(path.resolve(__dirname, '../scripts/status_check.sh'), { encoding: 'utf-8' })
+
+  return {
+    task: 'status check',
+    config: {
+      platform: 'linux',
+      image_resource: {
+        type: 'docker-image',
+        source: imageSource
+      },
+      inputs: [{ name: resource }],
+      params: {
+        RESOURCE: resource,
+        API_ROOT: apiRoot,
+      },
+      run: {
+        path: '/bin/bash',
+        args: [
+          '-cxe',
+          shellScript
+        ]
+      }
+    }
+  }
+}
+
+module.exports = task

--- a/bakery/src/tasks/status-check.js
+++ b/bakery/src/tasks/status-check.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const path = require('path')
 
 const task = (taskArgs) => {
-  const { resource, apiRoot } = taskArgs
+  const { resource, apiRoot, processingStates, completedStates, abortedStates } = taskArgs
   const imageDefault = {
     name: 'openstax/cops-bakery-scripts',
     tag: 'trunk'
@@ -12,6 +12,10 @@ const task = (taskArgs) => {
   const imageSource = constructImageSource({ ...imageDefault, ...imageOverrides })
 
   const shellScript = fs.readFileSync(path.resolve(__dirname, '../scripts/status_check.sh'), { encoding: 'utf-8' })
+
+  const toBashCaseMatch = (list) => {
+    return `@(${list.join('|')})`
+  }
 
   return {
     task: 'status check',
@@ -24,7 +28,10 @@ const task = (taskArgs) => {
       inputs: [{ name: resource }],
       params: {
         RESOURCE: resource,
-        API_ROOT: apiRoot
+        API_ROOT: apiRoot,
+        PROCESSING_STATES: toBashCaseMatch(processingStates),
+        COMPLETED_STATES: toBashCaseMatch(completedStates),
+        ABORTED_STATES: toBashCaseMatch(abortedStates)
       },
       run: {
         path: '/bin/bash',

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -176,14 +176,14 @@
                       >
                         Repeat
                       </v-btn>
-                      <v-tooltip top>
-                        <template #activator="{ on, attrs }">
-                          <v-btn class="job-abort-button ma-2" color="red darken-1" outlined v-bind="attrs" v-on="on">
-                            Abort
-                          </v-btn>
-                        </template>
-                        <span>Not yet implemented!</span>
-                      </v-tooltip>
+                      <v-btn
+                        class="job-abort-button ma-2"
+                        color="red darken-1"
+                        outlined
+                        @click="abortJob(item.id)"
+                      >
+                        Abort
+                      </v-btn>
                     </v-col>
                   </v-row>
                   <v-row>
@@ -391,6 +391,8 @@ export default {
         return 'orange'
       } else if (status === 'completed') {
         return 'green'
+      } else if (status === 'aborted') {
+        return 'brown'
       } else {
         return 'grey'
       }
@@ -420,6 +422,13 @@ export default {
         this.submitCollection(collectionId, contentServerId, version, style, jobType)
         this.closeDialog()
       }
+    },
+    async abortJob (jobId) {
+      const data = {
+        status_id: 6
+      }
+      await this.$axios.$put(`/api/jobs/${jobId}`, data)
+      setTimeout(() => { this.getJobsImmediate() }, 1000)
     },
     async submitCollection (collectionId, contentServerId, version, astyle, jobType) {
       // This fails to queue the job silently so the rate limit duration shouldn't


### PR DESCRIPTION
How this works:
Every top level job (corresponding to pdf, git_pdf, etc.) is run in parallel alongside a status checker job, using `fail_fast`, meaning the entire job is interrupted if any task running in parallel fails. This status checker polls the CORGI backend, attempting to see if the status changes to aborted out from under the running task. If the status checker finds this is the case, it exits with a non-zero exit code. Because the jobs are running with `fail_fast`, concourse will also as a result interrupt the running job, even if it's in the middle of baking or something. If the status checker finds a different completed state (success or failure), then it gracefully exits with a zero exit code.

Two things to keep in mind with this change:
- This will not work if we have issues with concourse not reporting a completed/failed status to the backend when a build completes. If this seems to become an issue, we need to add an `ensure` hook on each job (or some really large timeout) that will make sure that we kick the job status out of processing to some completed state so that this parallel job can exit correctly.
- Instead of having hooks for only the pipeline job like before (which was nice, since we could be sure there were no reporting gaps), we now only manage `on_abort` and `on_error` hooks on a job level. `on_failure`, and `on_success` now need to be managed at the step level, since we now have two jobs running in parallel that need to cause different side-effects on failure.

Other alternatives and why I didn't start with them:
**Have a wrapper admin layer task around every task**
- While something like this would work nicely for something like progress reporting in the job details page, we would end up with situations where someone would try to cancel a job at the beginning of baking, in which case it would take up to an hour or more to actually stop the task running in concourse and free up resources.

**Have a wrapper admin layer injected into every task**
- Essentially the same as what is done here, but add 100% more bash magic and require that all the task images have the required dependencies.

**Have the abort button send a POST to the abort endpoint of concourse**
- Would require a new specialized resource that can record and pass the build number to each build, so that it could then be tossed back over to the CORGI backend
- Running fly in a CORGI node just for this purpose doesn't really make a whole lot of sense, so an API endpoint would be preferred, but concourse's API endpoints are not advertised as being stable. And even if we wanted to send a POST to the abort endpoint of concourse, we would need to give CORGI the authorization to do so, which would take some doing.
