### PR TITLE
Update bakery tasks to use kitchen Docker image

### DIFF
--- a/bakery/src/cli/execute.js
+++ b/bakery/src/cli/execute.js
@@ -505,6 +505,68 @@ const tasks = {
       }
     }
   },
+  'bake-kitchen-group': (parentCommand) => {
+    const commandUsage = 'bake-kitchen-group <slug> <recipename> <stylefile>'
+    const handler = async argv => {
+      const buildExec = path.resolve(BAKERY_PATH, 'build')
+
+      const imageDetails = imageDetailsFromArgs(argv)
+      const singleBookFlag = argv.single
+      const taskArgs = [`--taskargs=${JSON.stringify({
+        ...imageDetails,
+        singleBookFlag: singleBookFlag,
+        slug: argv.slug
+      })}`]
+      const taskContent = execFileSync(buildExec, ['task', 'bake-book-group', ...taskArgs])
+      const tmpTaskFile = tmp.fileSync()
+      fs.writeFileSync(tmpTaskFile.name, taskContent)
+
+      const styleName = argv.recipename
+      const tmpBookDir = tmp.dirSync()
+      fs.writeFileSync(path.resolve(tmpBookDir.name, 'style'), styleName)
+
+      const tmpRecipesDir = tmp.dirSync()
+      fs.mkdirSync(path.resolve(tmpRecipesDir.name, 'rootfs/styles/'), { recursive: true })
+      fs.copyFileSync(path.resolve(argv.stylefile), path.resolve(tmpRecipesDir.name, `rootfs/styles/${styleName}-pdf.css`))
+
+      const dataDir = path.resolve(argv.data, argv.slug)
+
+      await flyExecute([
+        '-c', tmpTaskFile.name,
+        `--input=book=${tmpBookDir.name}`,
+        input(dataDir, 'assembled-book-group'),
+        `--input=cnx-recipes-output=${tmpRecipesDir.name}`,
+        output(dataDir, 'baked-book-group'),
+        output(dataDir, 'group-style')
+      ], { image: argv.image, persist: argv.persist })
+    }
+    return {
+      command: commandUsage,
+      aliases: 'bgk',
+      describe: 'bake a book group using kitchen',
+      builder: yargs => {
+        yargs.usage(`Usage: ${process.env.CALLER || `$0 ${parentCommand}`} ${commandUsage}`)
+        yargs.positional('slug', {
+          describe: 'slug of collection to work on',
+          type: 'string'
+        }).positional('recipename', {
+          describe: 'kitchen recipe / book name',
+          type: 'string'
+        }).positional('stylefile', {
+          describe: 'path to style file',
+          type: 'string'
+        }).option('s', {
+          alias: 'single',
+          describe: 'process a single book',
+          type: 'boolean',
+          default: false
+        })
+      },
+      handler: argv => {
+        handler(argv).catch((err) => { console.error(err); process.exit(1) })
+      }
+    }
+  },
   'link-extras': (parentCommand) => {
     const commandUsage = 'link-extras <collid> <server>'
     const handler = async argv => {
@@ -650,6 +712,60 @@ const tasks = {
           type: 'string'
         }).positional('recipefile', {
           describe: 'path to recipe file',
+          type: 'string'
+        }).positional('stylefile', {
+          describe: 'path to style file',
+          type: 'string'
+        })
+      },
+      handler: argv => {
+        handler(argv).catch((err) => { console.error(err); process.exit(1) })
+      }
+    }
+  },
+  'bake-kitchen': (parentCommand) => {
+    const commandUsage = 'bake-kitchen <collid> <recipename> <stylefile>'
+    const handler = async argv => {
+      const buildExec = path.resolve(BAKERY_PATH, 'build')
+
+      const imageDetails = imageDetailsFromArgs(argv)
+      const taskArgs = imageDetails == null
+        ? []
+        : [`--taskargs=${JSON.stringify(imageDetails)}`]
+      const taskContent = execFileSync(buildExec, ['task', 'bake-book', ...taskArgs])
+      const tmpTaskFile = tmp.fileSync()
+      fs.writeFileSync(tmpTaskFile.name, taskContent)
+
+      const styleName = argv.recipename
+      const tmpBookDir = tmp.dirSync()
+      fs.writeFileSync(path.resolve(tmpBookDir.name, 'collection_id'), argv.collid)
+      fs.writeFileSync(path.resolve(tmpBookDir.name, 'style'), styleName)
+
+      const tmpRecipesDir = tmp.dirSync()
+      fs.mkdirSync(path.resolve(tmpRecipesDir.name, 'rootfs/styles/'), { recursive: true })
+      fs.copyFileSync(path.resolve(argv.stylefile), path.resolve(tmpRecipesDir.name, `rootfs/styles/${styleName}-pdf.css`))
+
+      const dataDir = path.resolve(argv.data, argv.collid)
+
+      await flyExecute([
+        '-c', tmpTaskFile.name,
+        `--input=book=${tmpBookDir.name}`,
+        input(dataDir, 'linked-extras'),
+        `--input=cnx-recipes-output=${tmpRecipesDir.name}`,
+        output(dataDir, 'baked-book')
+      ], { image: argv.image, persist: argv.persist })
+    }
+    return {
+      command: commandUsage,
+      aliases: 'bk',
+      describe: 'bake a book using kitchen',
+      builder: yargs => {
+        yargs.usage(`Usage: ${process.env.CALLER || `$0 ${parentCommand}`} ${commandUsage}`)
+        yargs.positional('collid', {
+          describe: 'collection id of collection to work on',
+          type: 'string'
+        }).positional('recipename', {
+          describe: 'kitchen recipe / book name',
           type: 'string'
         }).positional('stylefile', {
           describe: 'path to style file',
@@ -1454,7 +1570,9 @@ const yargs = require('yargs')
           .command(tasks['link-extras'](commandUsage))
           .command(tasks['link-single'](commandUsage))
           .command(tasks.bake(commandUsage))
+          .command(tasks['bake-kitchen'](commandUsage))
           .command(tasks['bake-group'](commandUsage))
+          .command(tasks['bake-kitchen-group'](commandUsage))
           .command(tasks.mathify(commandUsage))
           .command(tasks['mathify-single'](commandUsage))
           .command(tasks['build-pdf'](commandUsage))

--- a/bakery/src/scripts/bake_book_group.sh
+++ b/bakery/src/scripts/bake_book_group.sh
@@ -12,8 +12,6 @@ exec > >(tee "${COMMON_LOG_DIR}"/log >&2) 2>&1
 # FIXME: Separate style injection step from baking step. This is way too much work to change a line injected into the head tag
 style_file="cnx-recipes-output/rootfs/styles/$(cat "${BOOK_INPUT}"/style)-pdf.css"
 
-recipe_file="cnx-recipes-output/rootfs/recipes/$(cat "${BOOK_INPUT}"/style).css"
-
 if [[ -f "$style_file" ]]
     then
         cp "$style_file" "${BAKED_OUTPUT}"
@@ -30,7 +28,7 @@ for collection in "${ASSEMBLED_INPUT}/"*.assembled.xhtml; do
             continue
         fi
     fi
-    cnx-easybake -q "$recipe_file" "${ASSEMBLED_INPUT}/$slug_name.assembled.xhtml" "${BAKED_OUTPUT}/$slug_name.baked.xhtml"
+    /code/bake_root -b "$(cat "${BOOK_INPUT}"/style)" -r cnx-recipes-output/rootfs/recipes -i "${ASSEMBLED_INPUT}/$slug_name.assembled.xhtml" -o "${BAKED_OUTPUT}/$slug_name.baked.xhtml"
     if [[ -f "$style_file" ]]
         then
             sed -i "s%<\\/head>%<link rel=\"stylesheet\" type=\"text/css\" href=\"$(basename "$style_file")\" />&%" "${BAKED_OUTPUT}/$slug_name.baked.xhtml"

--- a/bakery/src/tasks/bake-book-group.js
+++ b/bakery/src/tasks/bake-book-group.js
@@ -4,7 +4,7 @@ const path = require('path')
 
 const task = (taskArgs) => {
   const imageDefault = {
-    name: 'openstax/cnx-easybake',
+    name: 'openstax/recipes',
     tag: 'trunk'
   }
   const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}

--- a/bakery/src/tasks/bake-book.js
+++ b/bakery/src/tasks/bake-book.js
@@ -4,7 +4,7 @@ const { constructImageSource } = require('../task-util/task-util')
 
 const task = (taskArgs) => {
   const imageDefault = {
-    name: 'openstax/cnx-easybake',
+    name: 'openstax/recipes',
     tag: 'trunk'
   }
   const imageOverrides = taskArgs != null && taskArgs.image != null ? taskArgs.image : {}
@@ -36,7 +36,7 @@ const task = (taskArgs) => {
 
           cp -r linked-extras/* baked-book
           book_dir="baked-book/$(cat book/collection_id)"
-          cnx-easybake -q "cnx-recipes-output/rootfs/recipes/$(cat book/style).css" "$book_dir/collection.linked.xhtml" "$book_dir/collection.baked.xhtml"
+          /code/bake_root -b "$(cat book/style)" -r cnx-recipes-output/rootfs/recipes -i "$book_dir/collection.linked.xhtml" -o "$book_dir/collection.baked.xhtml"
           style_file="cnx-recipes-output/rootfs/styles/$(cat book/style)-pdf.css"
           if [ -f "$style_file" ]
           then


### PR DESCRIPTION
The changes in this PR to switch from the `openstax/cnx-easybake` image to `openstax/recipes` are pretty straight forward. I've tested local CORGI pipelines, and by toggling the style input from `chemistry2e` to anything else, it will trigger the kitchen baking vs legacy respectively.

The other change is to add designated baking tasks to the CLI for baking with `kitchen`. The legacy commands require an input of a path to a recipes file. The new commands instead require a recipe name (as defined in the `openstax/recipes` repo) and styles devs can still use the `stylefile` input to pass in any local style file they desire. For example, today they can use recipe name `chemistry2e` (so kitchen invokes the desired ruby script) and the `chemistry-pdf.css` style file from `cnx-recipes`. 