### PR TITLE
Add CLI Wrapper around the bakery CLI

### DIFF
--- a/bakery/package-lock.json
+++ b/bakery/package-lock.json
@@ -127,6 +127,11 @@
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
+    "@types/npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@types/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-4QQmOF5KlwfxJ5IGXFIudkeLCdMABz03RcUXu+LCb24zmln8QW6aDjuGl4d4XPVLf2j+FnjelHTP7dvceAFbhA=="
+    },
     "acorn": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
@@ -249,6 +254,20 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
+      }
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -726,6 +745,11 @@
         "convert-to-spaces": "^1.0.1"
       }
     },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -805,6 +829,11 @@
         "xdg-basedir": "^4.0.0"
       }
     },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
@@ -825,6 +854,11 @@
       "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz",
       "integrity": "sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU=",
       "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -1028,6 +1062,11 @@
           }
         }
       }
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -1643,6 +1682,54 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -1769,6 +1856,11 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "has-yarn": {
       "version": "2.1.0",
@@ -2094,8 +2186,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -2455,11 +2546,26 @@
       "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
       "dev": true
     },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-inspect": {
       "version": "1.7.0",
@@ -2904,6 +3010,11 @@
         "parse-ms": "^2.1.0"
       }
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -3044,6 +3155,20 @@
         }
       }
     },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "readdirp": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
@@ -3179,8 +3304,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -3232,8 +3356,7 @@
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "slash": {
       "version": "3.0.0",
@@ -3433,6 +3556,14 @@
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -3733,6 +3864,11 @@
         "prepend-http": "^2.0.0"
       }
     },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
     "v8-compile-cache": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
@@ -3786,6 +3922,43 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "widest-line": {
       "version": "3.1.0",

--- a/bakery/package.json
+++ b/bakery/package.json
@@ -6,8 +6,11 @@
     "package": "mkdir -p dist && cd dist && npm pack ../"
   },
   "dependencies": {
+    "@types/npmlog": "^4.1.2",
     "dedent": "^0.7.0",
     "js-yaml": "^3.13.1",
+    "npmlog": "^4.1.2",
+    "strip-ansi": "^6.0.0",
     "tmp": "^0.1.0",
     "wait-port": "^0.2.7",
     "which": "^2.0.2",

--- a/bakery/poet-cli
+++ b/bakery/poet-cli
@@ -1,0 +1,252 @@
+#!/bin/bash
+
+# Turn on tracing if desired
+if [[ ${LOG_LEVEL} == "trace" ]]
+then
+  export PS4='+ [${BASH_SOURCE##*/}:${LINENO}] '
+  set -x
+fi
+
+
+root_dir=$(dirname "$0")
+temp_dir="${BAKERY_DATA_DIR:=${root_dir}/temp}"
+abl_dir="${temp_dir}/content-manager-approved-books"
+
+steps_to_run='' # Collect all the steps that need to run. We will check for a substring in them to see if the operation is enabled
+skip_existing=0 # or 1 if true
+passthrough_args=''
+book_names=()
+
+c_yellow=$(tput setaf 11)
+c_none=$(tput sgr0)
+_say() {
+    >&2 echo "$*"
+}
+warn() {
+    _say "${c_yellow}Warning: $*${c_none}"
+}
+die() {
+    _say "$0: $*";
+    # shellcheck disable=SC2086
+    exit ${2:-112} # Use the 2nd arg or 112 as the default
+}
+try() { "$@" || die "ERROR: could not run [$*]"; }
+
+
+[[ -d "${temp_dir}" ]] || mkdir "${temp_dir}"
+[[ -d "${abl_dir}" ]] || (_say "Cloning ABL to temp dir"; sleep 10; cd "${temp_dir}" || exit 1; git clone https://github.com/openstax/content-manager-approved-books || exit 1)
+
+
+
+# Returns the following:
+# - book_uuid
+# - collection_id
+# - book_style
+# - book_server
+parse_book_info() {
+    local book_name=$1
+    local book_entry
+
+    # Convert book_slug to a UUID
+    book_uuid=$(jq -r --arg book_slug "${book_name}" 'reduce .[] as $item ({}; . + {($item.slug): $item.uuid}) | .[$book_slug]' < "${abl_dir}/book-slugs.json")
+    if [[ ${book_uuid} == 'null' ]]
+    then
+        die "Could not find book named '${book_name}' in the book-slugs.json file"
+    fi
+
+    # Get the collection ID from the book UUID
+    book_entry=$(jq --arg book_uuid "${book_uuid}" 'reduce .[] as $item ({}; . + {($item.uuid): {name: $item.name, collection_id: $item.collection_id, style: $item.style, server: $item.server}}) | .[$book_uuid]' < "${abl_dir}/approved-books.json")
+
+    collection_id=$(echo "${book_entry}" | jq -r '.collection_id')
+    book_style=$(echo "${book_entry}" | jq -r '.style')
+    book_server=$(echo "${book_entry}" | jq -r '.server')
+
+    if [[ ${collection_id} == 'null' || ${book_style} == 'null' || ${book_server} == 'null' ]]
+    then
+        _say "Skipping '${book_name}' because it does not have an entry in the ABL"
+        return 1
+    fi
+    return 0
+}
+
+do_book() {
+    local book_name=$1
+
+    parse_book_info "${book_name}"
+    return_code=$?
+    [[ ${return_code} == 0 ]] || return ${return_code}
+
+    # At this point the following have been defined:
+    # - book_uuid
+    # - collection_id
+    # - book_style
+    # - book_server
+    generic_args="--data ${temp_dir} ${passthrough_args}"
+    book_col_id=${collection_id}
+    server=${book_server}
+    recipe_name=${book_style}
+    style_file=${book_style}
+
+    for cur_operation in ${all_steps_to_run}
+    do
+        if [[ ${steps_to_run} =~ ${cur_operation} ]]
+        then
+            pointer=dir_for_${cur_operation//-/_} # https://stackoverflow.com/a/55331060 and https://stackoverflow.com/a/5928254
+            test_dir="${temp_dir}/${book_col_id}/${!pointer}"
+            if [[ ${skip_existing} == 0 || ! -d "${test_dir}" ]]
+            then
+                _say "${c_yellow}==>${c_none} ${cur_operation} ${book_name}"
+
+                # Special-case fetch has weird commandline arguments
+                if [[ ${cur_operation} == "${_fetch_arg}" ]]
+                then
+                    try node ./src/cli/execute.js run "${cur_operation}" ${generic_args} "${server}" "${book_col_id}" latest
+                
+                # 'bake' also has weird commandline arguments
+                elif [[ ${cur_operation} == "${_bake_arg}" ]]
+                then
+                    # Verify that the files exist before baking
+                    recipe_file=${CNX_RECIPES_DIR}/recipes/output/${recipe_name}.css
+                    style_file=${CNX_RECIPES_DIR}/styles/output/${recipe_name}-pdf.css
+
+                    [[ -f "${recipe_file}" ]] || die "recipe file not found: ${recipe_file}"
+                    [[ -f "${style_file}" ]] || warn "style file not found. using physics-pdf.css" && sleep 10 && style_file=${CNX_RECIPES_DIR}/styles/output/physics-pdf.css
+                    
+                    try node ./src/cli/execute.js run "${cur_operation}" ${generic_args} "${book_col_id}" "${CNX_RECIPES_DIR}/recipes/output/${recipe_name}.css" "${CNX_RECIPES_DIR}/styles/output/${recipe_name}-pdf.css"
+                
+                # 'link-extras' also has weird commandline arguments
+                elif [[ ${cur_operation} == "${_linkextras_arg}" ]]
+                then
+                    try node ./src/cli/execute.js run "${cur_operation}" ${generic_args} "${book_col_id}" "${server}"
+                else
+                    try node ./src/cli/execute.js run "${cur_operation}" ${generic_args} "${book_col_id}"
+                fi
+
+            else
+                warn "Skipping ${book_name} step ${cur_operation} because dir already exists: '${test_dir}'"
+            fi
+        fi
+    done
+
+}
+
+
+_fetch_arg='fetch'
+_assemble_arg='assemble'
+_linkextras_arg='link-extras'
+_bake_arg='bake'
+_mathify_arg='mathify'
+_pdf_arg='build-pdf'
+
+# These are used by --skip-existing . If these directories exist then we can skip the step (in the variable name).
+# Search for `dir_for_` in the rest of the code to see where it is used.
+dir_for_fetch='fetched-book'
+dir_for_assemble='assembled-book'
+dir_for_link_extras='linked-extras'
+dir_for_bake='baked-book'
+dir_for_mathify='mathified-book'
+dir_for_build_pdf='artifacts'
+
+all_steps_to_run="${_fetch_arg} ${_assemble_arg} ${_linkextras_arg} ${_bake_arg} ${_mathify_arg} ${_pdf_arg}"
+
+usage() {
+    _say "Usage $(basename "$0") [operations] [optional_book_name]"
+    _say ''
+    _say 'Operations can be one or more of the following:'
+    _say "    -${_fetch_arg}"
+    _say "    -${_assemble_arg}"
+    _say "    -${_linkextras_arg}"
+    _say "    -${_bake_arg}"
+    _say "    -${_mathify_arg}"
+    _say "    -${_pdf_arg}"
+    _say "    (add more as you use them)"
+    _say ""
+    _say "    --all           : Run on all books"
+    _say "    --skip-existing : If the output directory of an operation already exists then this will skip the step"
+    _say ""
+    _say "Arguments that are passed on to the bakery CLI:"
+    _say "    --persist"
+    _say "    --data     (TODO)"
+    _say "    --image    (TODO)"
+    _say "    --tag      (TODO)"
+    _say ""
+    _say "Environment Variables:"
+    _say "    CNX_RECIPES_DIR=/path/to : specifies the directory to look for the cnx-recipes repository root"
+    _say "    BAKERY_DATA_DIR=/path/to : specifies a directory to use. default is ./temp/"
+    _say "    LOG_LEVEL=trace          : enables verbose logging of each line that is executed"
+    exit 1
+}
+
+
+while [[ $# -gt 0 ]]
+do
+    key="$1"
+
+    case $key in
+        -${_fetch_arg} | -${_assemble_arg} | -${_bake_arg} | -${_mathify_arg} | -${_pdf_arg})
+            steps_to_run="${steps_to_run} ${key}"
+            shift
+        ;;
+        --all)
+            book_slug_names=$(jq -r '.[].slug' < "${abl_dir}/book-slugs.json")
+
+            for book_name in ${book_slug_names}; do
+                book_names+=("${book_name}")
+            done
+            shift
+        ;;
+        --skip-existing)
+            skip_existing=1
+            shift
+        ;;
+        --persist)
+            passthrough_args="${passthrough_args} --persist"
+        ;;
+        -h|--help)
+            usage
+        ;;
+        -*)
+            _say "Invalid option '${key}'"
+            usage
+        ;;
+        *) # All other arguments should be positional Books to use
+            book_names+=("$1") # save it in an array for later
+            shift
+        ;;
+    esac
+done
+
+if [[ ${steps_to_run} == '' ]]
+then
+    warn "Running all steps because none were specified"
+    sleep 2
+    steps_to_run=${all_steps_to_run}
+fi
+
+if [[ ${steps_to_run} =~ ${_bake_arg} && ! -d "${CNX_RECIPES_DIR}" ]]
+then
+    die "missing environment variable. ${_bake_arg} requires a valid CNX_RECIPES_DIR environment variable to be set"
+fi
+
+# If the user did not specify any books then run against all the books
+book_names_len=${#book_names[@]}
+if [[ ${book_names_len} == 0 ]]
+then
+    _say "ERROR: No books were specified. Use --all or specify a book name"
+    _say "Valid book names (from the ABL book list):"
+    book_slug_names=$(jq -r '.[].slug' < "${abl_dir}/book-slugs.json")
+
+    for book_name in ${book_slug_names}; do
+        _say "    ${book_name}"
+    done
+    exit 1
+fi
+
+
+
+for book_name in "${book_names[@]}"
+do
+    do_book "${book_name}"
+done
+
+_say "The output is available here: ${test_dir}"

--- a/bakery/poet-cli
+++ b/bakery/poet-cli
@@ -33,10 +33,6 @@ die() {
 try() { "$@" || die "ERROR: could not run [$*]"; }
 
 
-[[ -d "${temp_dir}" ]] || mkdir "${temp_dir}"
-[[ -d "${abl_dir}" ]] || (_say "Cloning ABL to temp dir"; sleep 10; cd "${temp_dir}" || exit 1; git clone https://github.com/openstax/content-manager-approved-books || exit 1)
-
-
 
 # Returns the following:
 # - book_uuid
@@ -215,6 +211,11 @@ do
         ;;
     esac
 done
+
+# Ensure directories exist
+[[ -d "${temp_dir}" ]] || mkdir "${temp_dir}"
+[[ -d "${abl_dir}" ]] || (_say "Cloning ABL to temp dir"; sleep 10; cd "${temp_dir}" || exit 1; git clone https://github.com/openstax/content-manager-approved-books || exit 1)
+
 
 if [[ ${steps_to_run} == '' ]]
 then

--- a/bakery/poet-cli
+++ b/bakery/poet-cli
@@ -11,10 +11,15 @@ fi
 root_dir=$(dirname "$0")
 temp_dir="${BAKERY_DATA_DIR:=${root_dir}/temp}"
 abl_dir="${temp_dir}/content-manager-approved-books"
+if [[ ${ABL_DIR} ]]
+then
+    abl_dir=${ABL_DIR}
+fi
 
 steps_to_run='' # Collect all the steps that need to run. We will check for a substring in them to see if the operation is enabled
 skip_existing=0 # or 1 if true
 passthrough_args=''
+print_versions=0
 book_names=()
 
 c_yellow=$(tput setaf 11)
@@ -39,9 +44,12 @@ try() { "$@" || die "ERROR: could not run [$*]"; }
 # - collection_id
 # - book_style
 # - book_server
+# - book_versions
 parse_book_info() {
     local book_name=$1
     local book_entry
+
+    # See https://github.com/stedolan/jq/wiki/Cookbook and https://stedolan.github.io/jq/manual/ for jq Documentation
 
     # Convert book_slug to a UUID
     book_uuid=$(jq -r --arg book_slug "${book_name}" 'reduce .[] as $item ({}; . + {($item.slug): $item.uuid}) | .[$book_slug]' < "${abl_dir}/book-slugs.json")
@@ -56,6 +64,8 @@ parse_book_info() {
     collection_id=$(echo "${book_entry}" | jq -r '.collection_id')
     book_style=$(echo "${book_entry}" | jq -r '.style')
     book_server=$(echo "${book_entry}" | jq -r '.server')
+
+    book_versions=$(jq -r --arg book_uuid "${book_uuid}" '.[] | select(.uuid == $book_uuid).version' < "${abl_dir}/approved-books.json")
 
     if [[ ${collection_id} == 'null' || ${book_style} == 'null' || ${book_server} == 'null' ]]
     then
@@ -118,6 +128,10 @@ do_book() {
                     try node ./src/cli/execute.js run "${cur_operation}" ${generic_args} "${book_col_id}"
                 fi
 
+                # Save the hash of this directory so we can tell if it has changed
+                # & therefore subsequent steps need to re-run
+                pushd "${test_dir}" && find . -type f -exec md5sum {} \; | md5sum > "${test_dir}.dir.md5" && popd
+
             else
                 warn "Skipping ${book_name} step ${cur_operation} because dir already exists: '${test_dir}'"
             fi
@@ -143,6 +157,14 @@ dir_for_bake='baked-book'
 dir_for_mathify='mathified-book'
 dir_for_build_pdf='artifacts'
 
+inputs_for_fetch=''
+inputs_for_assemble='fetch'
+inputs_for_link_extras='assemble'
+inputs_for_bake='link-extras'
+inputs_for_mathify='bake'
+inputs_for_build_pdf='mathify'
+
+
 all_steps_to_run="${_fetch_arg} ${_assemble_arg} ${_linkextras_arg} ${_bake_arg} ${_mathify_arg} ${_pdf_arg}"
 
 usage() {
@@ -159,6 +181,7 @@ usage() {
     _say ""
     _say "    --all           : Run on all books"
     _say "    --skip-existing : If the output directory of an operation already exists then this will skip the step"
+    _say "    --versions      : Print all the versions of each book in the Approved Book List (ABL)"
     _say ""
     _say "Arguments that are passed on to the bakery CLI:"
     _say "    --persist"
@@ -170,6 +193,9 @@ usage() {
     _say "    CNX_RECIPES_DIR=/path/to : specifies the directory to look for the cnx-recipes repository root"
     _say "    BAKERY_DATA_DIR=/path/to : specifies a directory to use. default is ./temp/"
     _say "    LOG_LEVEL=trace          : enables verbose logging of each line that is executed"
+    _say "    ABL_DIR=/path/to         : specifies the directory of the cloned local copy of"
+    _say "                               https://github.com/openstax/content-manager-approved-books"
+    _say "                               Default is BAKERY_DATA_DIR/content-manager-approved-books"
     exit 1
 }
 
@@ -197,6 +223,10 @@ do
         ;;
         --persist)
             passthrough_args="${passthrough_args} --persist"
+        ;;
+        --versions)
+            print_versions=1
+            shift
         ;;
         -h|--help)
             usage
@@ -231,14 +261,21 @@ fi
 
 # If the user did not specify any books then run against all the books
 book_names_len=${#book_names[@]}
-if [[ ${book_names_len} == 0 ]]
+if [[ ${book_names_len} == 0 || ${print_versions} == 1 ]]
 then
     _say "ERROR: No books were specified. Use --all or specify a book name"
     _say "Valid book names (from the ABL book list):"
-    book_slug_names=$(jq -r '.[].slug' < "${abl_dir}/book-slugs.json")
+    book_slug_names=$(jq -r '.[].slug' < "${abl_dir}/book-slugs.json" | sort)
 
     for book_name in ${book_slug_names}; do
-        _say "    ${book_name}"
+        if [[ ${print_versions} == 1 ]]
+        then
+            parse_book_info "${book_name}"
+            # book_versions is now defined
+            _say "${book_name} @ ${book_versions}"
+        else
+            _say "${book_name}"
+        fi
     done
     exit 1
 fi


### PR DESCRIPTION
The bakery CLI operations expect different arguments for different steps and require things like collection ids and server names and a path to recipes for some steps.

This wraps the bakery CLI so that the commands are simpler:

```
poet-cli -fetch physics
poet-cli -assemble -bake physics
poet-cli physics                    # Do all the steps for the physics book
poet-cli --skip-existing physics    # Skip any steps that have already ran
```