### PR TITLE
fix Ctrl+C so it results in non-zero exit status

### DIFF
--- a/bakery/package-lock.json
+++ b/bakery/package-lock.json
@@ -3148,6 +3148,7 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -3588,11 +3589,21 @@
       "dev": true
     },
     "tmp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
       "requires": {
-        "rimraf": "^2.6.3"
+        "rimraf": "^3.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "to-readable-stream": {

--- a/bakery/package.json
+++ b/bakery/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "dedent": "^0.7.0",
     "js-yaml": "^3.13.1",
-    "tmp": "^0.1.0",
+    "tmp": "^0.2.0",
     "wait-port": "^0.2.7",
     "which": "^2.0.2",
     "yargs": "^15.1.0"


### PR DESCRIPTION
If you press Ctrl+C while running the Bakery CLI it will result in a 0 exit status. This is incorrect & causes scripts that use the Bakery CLI to incorrectly believe the operation succeeded.

Here is a minimal example that illustrated the problem:

```js
require('tmp')      // <-- This is the culprit.

// Just sleep for 10 seconds so you can press Ctrl+C
const sleep = (ms) => new Promise((resolve) => setTimeout(() => resolve, ms))
sleep(10 * 1000)
```

Fixed in `tmp@0.2.0` (see https://github.com/raszi/node-tmp issue 233)