### PR TITLE
Fix issues related to git collection inputs with trailing spaces

### DIFF
--- a/bakery/src/tasks/look-up-book.js
+++ b/bakery/src/tasks/look-up-book.js
@@ -51,7 +51,7 @@ const task = (taskArgs) => {
               ;;
             git)
               cat ${inputSource}/collection_id | awk -F'/' '{ print $1 }' > book/repo
-              cat ${inputSource}/collection_id | awk -F'/' '{ print $2 }' > book/slug
+              cat ${inputSource}/collection_id | awk -F'/' '{ print $2 }' | sed 's/ *$//' > book/slug
               pdf_filename="$(cat book/slug)-$(cat book/version)-git-$(cat book/job_id).pdf"
               echo "$pdf_filename" > book/pdf_filename
               ;;

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -342,7 +342,7 @@ export default {
     this.serverRules = [v => !!v || 'Please select a server']
     this.gitCollectionRules = [
       v => !!v || 'Repo and slug are required',
-      v => /[a-zA-Z0-9-_]+\/[a-zA-Z0-9-_]+/.test(v) || 'A valid repo and slug name is required, e.g. repo-name/slug-name'
+      v => /[a-zA-Z0-9-_]+\/[a-zA-Z0-9-_]+$/.test(v) || 'A valid repo and slug name is required, e.g. repo-name/slug-name'
     ]
     this.headers = [
       {


### PR DESCRIPTION
This change addresses the issue found in QA in two places:
* UI side: Git collection inputs with trailing spaces will no longer pass form validation (this was already the case for archive jobs)
* Server side: The `look-up-book` task will strip any trailing spaces when parsing the slug from the input collection on git jobs