### PR TITLE
Fix doc errors during build step

### DIFF
--- a/docs/distribution/overview.rst
+++ b/docs/distribution/overview.rst
@@ -1,9 +1,9 @@
 .. _distribution-pipeline-overview:
 
 
-##############
+########
 Overview
-##############
+########
 
 The Distribution Pipeline generates JSON files corresponding to the page and book
 contents. The source repository contains schemas for the

--- a/docs/distribution/steps.rst
+++ b/docs/distribution/steps.rst
@@ -68,7 +68,7 @@ You should see no pipelines running.
 -------
 
 2. Define Pipeline Environment Variables
-=====================================
+========================================
 The Distribution Pipeline is configured using multiple variables in the environment
 specific JSON file in ``bakery/env``. Some of these are shared with the PDF pipeline,
 while others pertain only to it:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,9 +5,9 @@
 
 ----
 
-############################################
+######################################################
 Content Output Review and Generation Interface (CORGI)
-############################################
+######################################################
 
 CORGI an overarching system that contain different ways to 
 produce Openstax book content for various users (Content Manangers (CMs), 
@@ -41,6 +41,8 @@ CORGI at a Glance
    operations/updating_bakery_scripts
    operations/generate_pipeline_config
    operations/cli
+   operations/find_git_ref
+   operations/select_code_version_tag
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
There were a number of very basic build errors during the building of the documentation. I wanted to clean these up first before I start the bigger effort of renaming things.