### PR TITLE
Pin the backend/tests.dockerfile to avoid caching issues with latest

### DIFF
--- a/backend/tests.dockerfile
+++ b/backend/tests.dockerfile
@@ -1,4 +1,4 @@
-FROM openstax/selenium-chrome-debug:latest
+FROM openstax/selenium-chrome-debug:20210303.201802
 
 USER root
 


### PR DESCRIPTION
Pin the dockerhub tag of the selenium-chrome-debug image to avoid errors where "latest" is cached locally.