### PR TITLE
use relative time for jobs

### DIFF
--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -217,9 +217,9 @@
             </td>
           </template>
           <template #item.created_at="{ item }">
-            <span>
-              {{ $moment.utc(item.created_at).local().format('lll') }}
-            </span>
+            <time datetime="{{item.created_at}}" :title="$moment.utc(item.created_at).local().format('lll')">
+              {{ $moment.utc(item.created_at).fromNow() }}
+            </time>
           </template>
           <template #item.pdf_url="{ item }">
             <ul
@@ -254,9 +254,9 @@
             </v-chip>
           </template>
           <template #item.updated_at="{ item }">
-            <span>
-              {{ $moment.utc(item.updated_at).local().format('lll') }}
-            </span>
+            <time datetime="{{item.updated_at}}" :title="$moment.utc(item.updated_at).local().format('lll')">
+              {{ $moment.utc(item.updated_at).fromNow() }}
+            </time>
           </template>
         </v-data-table>
       </v-row>


### PR DESCRIPTION
It would be nice to see relatively how long ago jobs started and ended. Users can still hover over a time to get the date and time the job began/updated. I am not sure if this is actually requested by vendors; I just wanted to see how recently jobs succeeded and did not want to do the mental math.

(Note to self) Any objections to start calling this repo https://github.com/openstax/corgi ? 😉 

![image](https://user-images.githubusercontent.com/253202/112678995-a48e4780-8e39-11eb-9cda-05635eec2e55.png)
