### PR TITLE
Ensure revised time formats are ISO8601 in book and page outputs

### DIFF
--- a/bakery/src/scripts/assemble_book_metadata.py
+++ b/bakery/src/scripts/assemble_book_metadata.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 from cnxepub.collation import reconstitute
 from cnxepub.models import flatten_to_documents
+from . import utils
 
 
 def main():
@@ -25,7 +26,7 @@ def main():
         revised = uuid_to_revised_map.get(doc.id) or doc.metadata["revised"]
         json_data[doc.ident_hash] = {
             "abstract": abstract,
-            "revised": revised
+            "revised": utils.ensure_isoformat(revised)
         }
 
     with open(output_file_path, "w") as out_file:

--- a/bakery/src/scripts/bake_book_metadata.py
+++ b/bakery/src/scripts/bake_book_metadata.py
@@ -39,7 +39,7 @@ def main():
 
     baked_book_json = {
         "title": metadata.title,
-        "revised": metadata.revised,
+        "revised": utils.ensure_isoformat(metadata.revised),
         "tree": tree,
         "slug": book_slug,
         "id": book_metadata.get("id") or binder.id,

--- a/bakery/src/scripts/book-schema-git.json
+++ b/bakery/src/scripts/book-schema-git.json
@@ -19,7 +19,8 @@
     },
     "revised": {
       "type": "string",
-      "description": "The revision date of this version of the book"
+      "description": "The revision date of this version of the book as ISO8601",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}([.]\\d+)?(Z|[+-]\\d{2}:\\d{2})$"
     },
     "license": {
       "type": "object",

--- a/bakery/src/scripts/book-schema.json
+++ b/bakery/src/scripts/book-schema.json
@@ -30,7 +30,8 @@
     },
     "revised": {
       "type": "string",
-      "description": "The revision date of this version of the book"
+      "description": "The revision date of this version of the book as ISO8601",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}([.]\\d+)?(Z|[+-]\\d{2}:\\d{2})$"
     },
     "license": {
       "type": "object",

--- a/bakery/src/scripts/disassemble_book.py
+++ b/bakery/src/scripts/disassemble_book.py
@@ -2,7 +2,7 @@ import sys
 import json
 from . import utils
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 
 from lxml import etree
 from lxml.builder import ElementMaker, E
@@ -202,7 +202,7 @@ def main():
                 "title": doc.metadata.get("title"),
                 "abstract": None,
                 "id": doc.id,
-                "revised": datetime.now().isoformat()
+                "revised": datetime.now(timezone.utc).isoformat()
             }
 
             # Add / override metadata from baking if available

--- a/bakery/src/scripts/page-schema.json
+++ b/bakery/src/scripts/page-schema.json
@@ -23,7 +23,8 @@
     },
     "revised": {
       "type": "string",
-      "description": "The revision date for the page"
+      "description": "The revision date for the page as ISO8601",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}([.]\\d+)?(Z|[+-]\\d{2}:\\d{2})$"
     },
     "content": {
       "type": "string",

--- a/bakery/src/scripts/requirements.txt
+++ b/bakery/src/scripts/requirements.txt
@@ -8,3 +8,4 @@ python-magic==0.4.15
 google-api-python-client==1.10.0
 pygit2==1.4.0
 Pillow==8.1.1
+python-dateutil==2.8.1

--- a/bakery/src/tests/data/collection.baked.xhtml
+++ b/bakery/src/tests/data/collection.baked.xhtml
@@ -14,7 +14,7 @@
 
 
   <meta itemprop="dateCreated" content="2012-01-23T01:03:30-06:00"/>
-  <meta itemprop="dateModified" content="2019-08-30T16:35:37.569966-05:00"/>
+  <meta itemprop="dateModified" content="2021/02/26 10:51:35.574 US/Central"/>
 </head>
 
 <body itemscope="itemscope" itemtype="http://schema.org/Book">

--- a/bakery/src/tests/test_bakery_scripts.py
+++ b/bakery/src/tests/test_bakery_scripts.py
@@ -966,7 +966,7 @@ def test_bake_book_metadata(tmp_path, mocker):
     assert "license" in book_metadata.keys()
     assert (
         book_metadata["revised"]
-        == "2021-02-26T10:51:35.574000-05:00"
+        == "2021-02-26T10:51:35.574000-06:00"
     )
     assert "College Physics" in book_metadata["title"]
     assert book_metadata["slug"] == "test-book-slug"
@@ -2981,7 +2981,7 @@ def test_ensure_isoformat():
     assert utils.ensure_isoformat("2018/10/01 14:04:45 -0500") == \
         "2018-10-01T14:04:45-05:00"
     assert utils.ensure_isoformat("2020/12/21 16:05:52.185 US/Central") == \
-        "2020-12-21T16:05:52.185000-05:00"
+        "2020-12-21T16:05:52.185000-06:00"
     assert utils.ensure_isoformat("2020/09/15 13:39:55.802 GMT-5") == \
         "2020-09-15T13:39:55.802000-05:00"
     assert utils.ensure_isoformat("2018/09/25 06:57:44 GMT-5") == \

--- a/bakery/src/tests/test_bakery_scripts.py
+++ b/bakery/src/tests/test_bakery_scripts.py
@@ -17,6 +17,7 @@ from googleapiclient.http import RequestMockBuilder
 from PIL import Image
 from pathlib import Path
 from filecmp import cmp
+from datetime import datetime
 
 from cnxepub.html_parsers import HTML_DOCUMENT_NAMESPACES
 from cnxepub.collation import reconstitute
@@ -36,6 +37,7 @@ from bakery_scripts import (
     fetch_update_metadata,
     link_single,
     patch_same_book_links,
+    utils
 )
 
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -247,6 +249,8 @@ def test_disassemble_book(tmp_path, mocker):
         == "Explain the difference between a model and a theory"
     )
     assert m42092_data["revised"] is not None
+    # Verify the generated timestamp is ISO8601 and includes timezone info
+    assert datetime.fromisoformat(m42092_data["revised"]).tzinfo is not None
 
     toc_output = disassembled_output / "collection.toc.xhtml"
     assert toc_output.exists()
@@ -883,11 +887,11 @@ def test_assemble_book_metadata(tmp_path, mocker):
     )
     assert (
         assembled_metadata["m42092@1.10"]["revised"]
-        == "2018/09/18 09:55:13.413 GMT-5"
+        == "2018-09-18T09:55:13.413000-05:00"
     )
     assert (
         assembled_metadata["m42119@1.6"]["revised"]
-        == "2018/08/03 15:49:52 -0500"
+        == "2018-08-03T15:49:52-05:00"
     )
 
 
@@ -912,11 +916,11 @@ def test_assemble_book_metadata_empty_revised_json(tmp_path, mocker):
     assembled_metadata = json.loads(assembled_metadata_output.read_text())
     assert (
         assembled_metadata["m42092@1.10"]["revised"]
-        == "2018/09/18 09:55:13.413 GMT-5"
+        == "2018-09-18T09:55:13.413000-05:00"
     )
     assert (
         assembled_metadata["m42119@1.6"]["revised"]
-        == "2018/08/03 15:49:52 -0500"
+        == "2018-08-03T15:49:52-05:00"
     )
 
 
@@ -962,7 +966,7 @@ def test_bake_book_metadata(tmp_path, mocker):
     assert "license" in book_metadata.keys()
     assert (
         book_metadata["revised"]
-        == "2019-08-30T16:35:37.569966-05:00"
+        == "2021-02-26T10:51:35.574000-05:00"
     )
     assert "College Physics" in book_metadata["title"]
     assert book_metadata["slug"] == "test-book-slug"
@@ -2966,3 +2970,24 @@ def test_link_single_with_flag(tmp_path, mocker):
             ["", str(baked_dir), str(baked_meta_dir), source_book_slug, str(linked_xhtml)]
         )
         link_single.main()
+
+
+def test_ensure_isoformat():
+    """Test ensure_isoformat utility function"""
+    assert utils.ensure_isoformat("2021-03-22T14:14:33.17588-05:00") == \
+        "2021-03-22T14:14:33.17588-05:00"
+    assert utils.ensure_isoformat("2021-03-23T11:34:33.989606-05:00") == \
+        "2021-03-23T11:34:33.989606-05:00"
+    assert utils.ensure_isoformat("2018/10/01 14:04:45 -0500") == \
+        "2018-10-01T14:04:45-05:00"
+    assert utils.ensure_isoformat("2020/12/21 16:05:52.185 US/Central") == \
+        "2020-12-21T16:05:52.185000-05:00"
+    assert utils.ensure_isoformat("2020/09/15 13:39:55.802 GMT-5") == \
+        "2020-09-15T13:39:55.802000-05:00"
+    assert utils.ensure_isoformat("2018/09/25 06:57:44 GMT-5") == \
+        "2018-09-25T06:57:44-05:00"
+    with pytest.raises(
+        Exception,
+        match="Could not convert non ISO8601 timestamp: unexpectedtimeformat"
+    ):
+        utils.ensure_isoformat("unexpectedtimeformat")


### PR DESCRIPTION
As part of code review, I'm particularly open to suggestions on a better way to do [this](https://github.com/openstax/output-producer-service/blob/4cd52ef923a4f372afefeb491cbacf7437ba9c2d/bakery/src/scripts/utils.py#L106-L126) handling as it feels really brittle, but given the input time formats seem pretty non-standard and inconsistent, I couldn't immediately think of a better way. As it is, those formats are based upon the ones I found used for `<md:revised>` in actual content files across 66 books(see [this comment](https://github.com/openstax/cnx/issues/1506#issuecomment-820711568) in the parent issue), so I think it hits all of the ones we can expect to see from archive at least.

The PR also adds validating timestamps as ISO8601 during the final schema check, so at least we should catch any remaining unexpected time formats in the pipeline.