### PR TITLE
Revert "Bump py from 1.8.0 to 1.10.0 in /backend/app/requirements"

### DIFF
--- a/backend/app/requirements/dev.txt
+++ b/backend/app/requirements/dev.txt
@@ -36,7 +36,7 @@ pluggy==0.13.1
 prometheus-client==0.7.1
 prompt-toolkit==3.0.2
 ptyprocess==0.6.0
-py==1.10.0
+py==1.8.0
 Pygments==2.7.4
 pyparsing==2.4.5
 pypom==2.2.0


### PR DESCRIPTION
Reverts openstax/output-producer-service#336