### PR TITLE
Don't fail fast in validate-xhtml task

### DIFF
--- a/bakery/src/tasks/validate-xhtml.js
+++ b/bakery/src/tasks/validate-xhtml.js
@@ -50,10 +50,14 @@ const task = (taskArgs) => {
               exit 1
               ;;
           esac
+          failure=false
           for xhtmlfile in $xhtmlfiles_path
           do
-            java -cp /xhtml-validator.jar org.openstax.xml.Main "$xhtmlfile" ${validationNames.join(' ')}
+            java -cp /xhtml-validator.jar org.openstax.xml.Main "$xhtmlfile" ${validationNames.join(' ')} || failure=true
           done
+          if $failure; then
+            exit 1
+          fi
         `
         ]
       }


### PR DESCRIPTION
Process all XHTML files and then exit with nonzero code if any fail
validation instead of exiting on the first failure.