### PR TITLE
Remove CNXML validation from CORGI pipeline

### DIFF
--- a/bakery/src/pipelines/cops.js
+++ b/bakery/src/pipelines/cops.js
@@ -7,7 +7,6 @@ const pipeline = (env) => {
   const taskMathifyBook = require('../tasks/mathify-book')
   const taskBuildPdf = require('../tasks/build-pdf')
   const taskValidateXhtml = require('../tasks/validate-xhtml')
-  const taskValidateCnxml = require('../tasks/validate-cnxml')
 
   const taskAssembleBookMeta = require('../tasks/assemble-book-metadata')
   const taskBakeBookMeta = require('../tasks/bake-book-metadata')
@@ -218,13 +217,6 @@ const pipeline = (env) => {
         image: imageOverrides,
         githubSecretCreds: env.GH_SECRET_CREDS
       }),
-      taskValidateCnxml({
-        image: imageOverrides,
-        inputSource: 'fetched-book-group',
-        modulesPath: 'raw/modules/**/*.cnxml',
-        collectionsPath: 'raw/collections/*.xml',
-        contentSource: 'git'
-      }),
       taskAssembleBookGroup({ image: imageOverrides }),
       taskAssembleBookMetadataGroup({ image: imageOverrides }),
       taskBakeBookGroup({ image: imageOverrides }),
@@ -261,12 +253,6 @@ const pipeline = (env) => {
       taskLookUpBook({ inputSource: resource, image: imageOverrides }),
       report(Status.PROCESSING),
       taskFetchBook({ image: imageOverrides }),
-      taskValidateCnxml({
-        image: imageOverrides,
-        inputSource: 'fetched-book',
-        modulesPath: 'raw/**/*.cnxml',
-        collectionsPath: 'raw/collection.xml'
-      }),
       taskAssembleBook({ image: imageOverrides }),
       taskLinkExtras({
         image: imageOverrides,
@@ -310,12 +296,6 @@ const pipeline = (env) => {
       taskLookUpBook({ inputSource: resource, image: imageOverrides }),
       report(Status.PROCESSING),
       taskFetchBook({ image: imageOverrides }),
-      taskValidateCnxml({
-        image: imageOverrides,
-        inputSource: 'fetched-book',
-        modulesPath: 'raw/**/*.cnxml',
-        collectionsPath: 'raw/collection.xml'
-      }),
       taskAssembleBook({ image: imageOverrides }),
       taskLinkExtras({
         image: imageOverrides,
@@ -371,13 +351,6 @@ const pipeline = (env) => {
       taskFetchBookGroup({
         image: imageOverrides,
         githubSecretCreds: env.GH_SECRET_CREDS
-      }),
-      taskValidateCnxml({
-        image: imageOverrides,
-        inputSource: 'fetched-book-group',
-        modulesPath: 'raw/modules/**/*.cnxml',
-        collectionsPath: 'raw/collections/*.xml',
-        contentSource: 'git'
       }),
       taskAssembleBookGroup({ image: imageOverrides }),
       taskAssembleBookMetadataGroup({ image: imageOverrides }),


### PR DESCRIPTION
The changes in this PR can be reverted once we have MathML 3.0 support in our schema so Polish physics books build successfully on CORGI with the CNXML validation enabled.