### PR TITLE
Scope validate cnxml glob to index.cnxml for archive

### DIFF
--- a/bakery/src/pipelines/cops.js
+++ b/bakery/src/pipelines/cops.js
@@ -264,7 +264,7 @@ const pipeline = (env) => {
       taskValidateCnxml({
         image: imageOverrides,
         inputSource: 'fetched-book',
-        modulesPath: 'raw/**/*.cnxml',
+        modulesPath: 'raw/**/index.cnxml',
         collectionsPath: 'raw/collection.xml'
       }),
       taskAssembleBook({ image: imageOverrides }),
@@ -313,7 +313,7 @@ const pipeline = (env) => {
       taskValidateCnxml({
         image: imageOverrides,
         inputSource: 'fetched-book',
-        modulesPath: 'raw/**/*.cnxml',
+        modulesPath: 'raw/**/index.cnxml',
         collectionsPath: 'raw/collection.xml'
       }),
       taskAssembleBook({ image: imageOverrides }),

--- a/bakery/src/pipelines/distribution.js
+++ b/bakery/src/pipelines/distribution.js
@@ -91,7 +91,7 @@ const pipeline = (env) => {
       taskValidateCnxml({
         image: imageOverrides,
         inputSource: 'fetched-book',
-        modulesPath: 'raw/**/*.cnxml',
+        modulesPath: 'raw/**/index.cnxml',
         collectionsPath: 'raw/collection.xml'
       }),
       taskAssembleBook({ image: imageOverrides }),

--- a/bakery/src/pipelines/gdoc.js
+++ b/bakery/src/pipelines/gdoc.js
@@ -91,7 +91,7 @@ const pipeline = (env) => {
       taskValidateCnxml({
         image: imageOverrides,
         inputSource: 'fetched-book',
-        modulesPath: 'raw/**/*.cnxml',
+        modulesPath: 'raw/**/index.cnxml',
         collectionsPath: 'raw/collection.xml'
       }),
       taskAssembleBook({ image: imageOverrides }),

--- a/bakery/src/tests/test_cli.js
+++ b/bakery/src/tests/test_cli.js
@@ -358,7 +358,7 @@ test('stable flow pipelines', async t => {
     'validate-cnxml',
     bookId,
     'fetched-book',
-    'raw/**/*.cnxml',
+    'raw/**/index.cnxml',
     'raw/collection.xml'
   ])
 


### PR DESCRIPTION
This is to avoid accidentally picking up CNXML resource files for
validation which may result in false positive errors. A similar
change isn't required for git content since resource files are
isolated to a separate directory prior to the validation step.