### PR TITLE
Show missing files during checksum

### DIFF
--- a/bakery/src/scripts/checksum_resource.py
+++ b/bakery/src/scripts/checksum_resource.py
@@ -59,6 +59,8 @@ def generate_checksum_resources_from_xhtml(filename, output_dir):
             create_symlink(img_filename, output_dir, sha1)
             create_json_metadata(output_dir, sha1, mime_type, s3_md5,
                                  img_basename)
+        else:
+            print('MISSING_FILE: {}'.format(img_filename))
 
     # get all a @href resources
     href_xpath = '//x:a[@href and not(starts-with(@href, "http") or ' \
@@ -82,6 +84,8 @@ def generate_checksum_resources_from_xhtml(filename, output_dir):
             create_symlink(img_filename, output_dir, sha1)
             create_json_metadata(output_dir, sha1, mime_type, s3_md5,
                                  img_basename)
+        else:
+            print('MISSING_FILE: {}'.format(img_filename))
 
     output_file = os.path.join(output_dir, basename)
     # note: non self closing tags in xhtml are probably not respected here

--- a/bakery/src/tests/test_bakery_scripts.py
+++ b/bakery/src/tests/test_bakery_scripts.py
@@ -90,6 +90,8 @@ def test_checksum_resource(tmp_path, mocker):
     html_content = ('<html xmlns="http://www.w3.org/1999/xhtml">'
                     '<img src="0/image_src.svg"/>'
                     '<a href="image_href.svg">linko</a>'
+                    '<img src="0/image_src_missing.jpg"/>'
+                    '<a href="image_href_missing.svg">linko</a>'
                     '</html>')
     html_file.write_text(html_content)
 
@@ -130,6 +132,8 @@ def test_checksum_resource(tmp_path, mocker):
     expected = (f'<html xmlns="http://www.w3.org/1999/xhtml">'
                 f'<img src="../resources/{image_src_sha1_expected}"/>'
                 f'<a href="../resources/{image_href_sha1_expected}">linko</a>'
+                '<img src="0/image_src_missing.jpg"/>'
+                '<a href="image_href_missing.svg">linko</a>'
                 f'</html>')
     assert etree.tostring(tree, encoding="utf8") == expected.encode("utf8")
 


### PR DESCRIPTION
During the checksum step some files may not be found. This is likely a content error but we do not fail on it yet.

But it is useful to know for debugging. Note there will still be entries like this from the astronomy book:

```
MISSING_FILE: /contents/810ba736-3e15-48e2-9491-cf0f401611c3
MISSING_FILE: /contents/a567ba98-3507-49d5-893c-c05cd42eefa5#fs-id1168048645820
MISSING_FILE: /contents/c4987953-c1a0-4df4-8d01-1d0df7ae228f
MISSING_FILE: /contents/bd9d6fca-fd83-4112-9379-482f40364ae7
```

Oh drat, those entries are probably the autogenerated end-of-chapter pages. If so then I see why these messages were suppressed