### PR TITLE
Fix task name string for override-common-log

### DIFF
--- a/bakery/src/tasks/override-common-log.js
+++ b/bakery/src/tasks/override-common-log.js
@@ -16,7 +16,7 @@ const task = (taskArgs) => {
   const shellScript = fs.readFileSync(path.resolve(__dirname, '../scripts/override_common_log.sh'), { encoding: 'utf-8' })
 
   return {
-    task: 'generate preview urls',
+    task: 'override common log',
     config: {
       platform: 'linux',
       image_resource: {


### PR DESCRIPTION
I happened to notice this in a recent deployment and was very confused for a second as to why we were generating preview URLs for a PDF job due to the incorrect label 😂 .