### PR TITLE
reduce the noise during book disassembly

### DIFF
--- a/bakery/src/scripts/disassemble_book.py
+++ b/bakery/src/scripts/disassemble_book.py
@@ -85,9 +85,6 @@ def main():
             '//xhtml:a[@href and starts-with(@href, "/contents/")]',
             namespaces=HTML_DOCUMENT_NAMESPACES
         ):
-            print('BEFORE:')
-            print(node.attrib)
-
             page_link = node.attrib["href"].split("/")[-1]
             # Link may have fragment
             if "#" in page_link:
@@ -102,9 +99,6 @@ def main():
                 node.attrib["data-page-slug"] = slugs.get(page_uuid)
                 node.attrib["data-page-uuid"] = page_uuid
                 node.attrib["data-page-fragment"] = page_fragment
-
-            print('AFTER:')
-            print(node.attrib)
 
         doc.content = etree_to_content(module_etree)
 


### PR DESCRIPTION
This reduces the noise during the disassemble_book step. I was running into problems running the steps through [kcov](https://simonkagstrom.github.io/kcov/) while adding tests in [book-pipeline](https://github.com/openstax/book-pipeline).

Is there an existing logger that could be used instead? I did not see any.