### PR TITLE
Add queued to process state for status check task

### DIFF
--- a/bakery/src/pipelines/cops.js
+++ b/bakery/src/pipelines/cops.js
@@ -92,7 +92,7 @@ const pipeline = (env) => {
                 resource: resource,
                 apiRoot: env.COPS_TARGET,
                 image: imageOverrides,
-                processingStates: [Status.ASSIGNED, Status.PROCESSING],
+                processingStates: [Status.QUEUED, Status.ASSIGNED, Status.PROCESSING],
                 completedStates: [Status.FAILED, Status.SUCCEEDED],
                 abortedStates: [Status.ABORTED]
               })


### PR DESCRIPTION
This change addresses a rare race condition where the status check
task queries CORGI before the pipeline is able to update the status
to ASSIGNED.