### PR TITLE
remove the silent HTML fallback in cnx-epub

### DIFF
--- a/bakery/src/scripts/disassemble_book.py
+++ b/bakery/src/scripts/disassemble_book.py
@@ -46,6 +46,7 @@ def main():
 
     with open(xhtml_file, "rb") as file:
         html_root = etree.parse(file)
+        file.seek(0)
         binder = reconstitute(file)
         slugs = extract_slugs_from_binder(binder)
 


### PR DESCRIPTION
cnx-epub was silently falling back to parsing the document as HTML when there was an XML parsing error. It turns out the XML parsing error was because the file was read once but the cursor was not set back to the beginning of the file

Alternate solution (both can be merged): https://github.com/openstax/cnx-epub/pull/183

Example HTML where the [MathML namespace is stripped](https://openstax.org/apps/archive/20210823.155019/contents/031da8d3-b525-429c-80cf-6c8ed997733a@23.42:c82515ee-02ef-4e15-9b4f-52e67617359c.xhtml)
