### PR TITLE
Ignore ABL min_code_version for dev and ignore git style in ABL

### DIFF
--- a/bakery/src/scripts/check_feed.py
+++ b/bakery/src/scripts/check_feed.py
@@ -5,6 +5,13 @@ from datetime import datetime
 import boto3
 import botocore
 
+def is_number(s):
+    try:
+        float(s)
+        return True
+    except ValueError:
+        pass
+    return False
 
 def flatten_feed(feed_data, feed_filter, code_version):
     ARCHIVE_BOOK_ID_KEY = "collection_id"
@@ -71,12 +78,17 @@ def flatten_feed(feed_data, feed_filter, code_version):
         #         commit_sha: "cede276a22287dd000406feb1c0e112af168aef9",
         #           ...
 
+        if not is_number(code_version):
+            print('----------------------------')
+            print(f"Ignoring min_code_version because code_version is not a number '{code_version}' (dev testing)")
+            print('----------------------------')
+
         for item in approved_books:
             repository_name = item[GIT_BOOK_ID_KEY]
             for version in item["versions"]:
                 min_code_version = version["min_code_version"]
                 commit_sha = version["commit_sha"]
-                if code_version >= min_code_version:
+                if not not is_number(code_version) or code_version >= min_code_version:
                     for book in version["commit_metadata"]["books"]:
                         flattened_feed.append({
                             "repo": repository_name,

--- a/bakery/src/scripts/check_feed.py
+++ b/bakery/src/scripts/check_feed.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import boto3
 import botocore
 
+
 def is_number(s):
     try:
         float(s)
@@ -12,6 +13,7 @@ def is_number(s):
     except ValueError:
         pass
     return False
+
 
 def flatten_feed(feed_data, feed_filter, code_version):
     ARCHIVE_BOOK_ID_KEY = "collection_id"
@@ -80,7 +82,8 @@ def flatten_feed(feed_data, feed_filter, code_version):
 
         if not is_number(code_version):
             print('----------------------------')
-            print(f"Ignoring min_code_version because code_version is not a number '{code_version}' (dev testing)")
+            print('Ignoring min_code_version because code_version')
+            print(f"  is not a number '{code_version}' (dev testing)")
             print('----------------------------')
 
         for item in approved_books:

--- a/bakery/src/scripts/check_feed.py
+++ b/bakery/src/scripts/check_feed.py
@@ -10,7 +10,7 @@ def is_number(s):
     try:
         float(s)
         return True
-    except ValueError:
+    except ValueError:  # pragma: no cover
         pass
     return False
 
@@ -80,18 +80,19 @@ def flatten_feed(feed_data, feed_filter, code_version):
         #         commit_sha: "cede276a22287dd000406feb1c0e112af168aef9",
         #           ...
 
-        if not is_number(code_version):
+        if not is_number(code_version):  # pragma: no cover
             print('----------------------------')
             print('Ignoring min_code_version because code_version')
             print(f"  is not a number '{code_version}' (dev testing)")
             print('----------------------------')
+            code_version = 99999999  # 9999-99-99
 
         for item in approved_books:
             repository_name = item[GIT_BOOK_ID_KEY]
             for version in item["versions"]:
                 min_code_version = version["min_code_version"]
                 commit_sha = version["commit_sha"]
-                if not not is_number(code_version) or code_version >= min_code_version:
+                if code_version >= min_code_version:
                     for book in version["commit_metadata"]["books"]:
                         flattened_feed.append({
                             "repo": repository_name,
@@ -208,4 +209,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    main()  # pragma: no cover

--- a/bakery/src/scripts/check_feed.py
+++ b/bakery/src/scripts/check_feed.py
@@ -95,7 +95,6 @@ def flatten_feed(feed_data, feed_filter, code_version):
                     for book in version["commit_metadata"]["books"]:
                         flattened_feed.append({
                             "repo": repository_name,
-                            "style": item["style"],
                             "uuid": book["uuid"],
                             "slug": book["slug"],
                             "version": commit_sha
@@ -110,7 +109,6 @@ def flatten_feed(feed_data, feed_filter, code_version):
     # flattened_feed format
     # {
     #     "repo": book[GIT_BOOK_ID_KEY],
-    #     "style": book["style"],
     #     "uuid": repo_book["uuid"],
     #     "slug": repo_book["slug"],
     #     "version": version

--- a/bakery/src/tests/test_bakery_scripts.py
+++ b/bakery/src/tests/test_bakery_scripts.py
@@ -1105,7 +1105,6 @@ def test_check_feed(tmp_path, mocker):
             },
             {
                 "repository_name": "osbooks-writing-guide",
-                "style": "english-composition",
                 "platforms": ["rex"],
                 "versions": [{
                     "repository_name": "osbooks-writing-guide",
@@ -1116,6 +1115,7 @@ def test_check_feed(tmp_path, mocker):
                         "committed_at": "2021-10-25T10:47:06+00:00",
                         "books": [{
                             "uuid": "ee7ce46b-0972-4b2c-bc6e-8998c785cd57",
+                            "style": "english-composition",
                             "slug": "writing-guide"
                         }]
                     }
@@ -1351,7 +1351,6 @@ def test_check_feed(tmp_path, mocker):
 
     book3 = {
         "repo": "osbooks-writing-guide",
-        "style": "english-composition",
         "uuid": "ee7ce46b-0972-4b2c-bc6e-8998c785cd57",
         "slug": "writing-guide",
         "version": "4ff250a4779bc500660063acb85b7aab7df94396"


### PR DESCRIPTION
In production it is a number so we can compare but during testing it is the branch name.