### PR TITLE
exclude slug from git books so that all will build

### DIFF
--- a/bakery/src/scripts/check_feed.py
+++ b/bakery/src/scripts/check_feed.py
@@ -93,13 +93,10 @@ def flatten_feed(feed_data, feed_filter, code_version):
                 min_code_version = version["min_code_version"]
                 commit_sha = version["commit_sha"]
                 if code_version >= min_code_version:
-                    for book in version["commit_metadata"]["books"]:
-                        flattened_feed.append({
-                            "repo": repository_name,
-                            "uuid": book["uuid"],
-                            "slug": book["slug"],
-                            "version": commit_sha
-                        })
+                    flattened_feed.append({
+                        "repo": repository_name,
+                        "version": commit_sha
+                    })
                 else:  # pragma: no cover
                     print(
                         "Skipping entry because codeversion is too new. "
@@ -134,8 +131,6 @@ def main():
     books_queued = 0
 
     flattened_feed = flatten_feed(feed_data, feed_filter, code_version)
-    # if (feed_filter == "git"):
-    #     raise Exception(flattened_feed)
 
     # Iterate through feed and check for a book that is not completed based
     # upon existence of a {code_version}/.{collection_id}@{version}.complete

--- a/bakery/src/tests/test_bakery_scripts.py
+++ b/bakery/src/tests/test_bakery_scripts.py
@@ -1351,8 +1351,6 @@ def test_check_feed(tmp_path, mocker):
 
     book3 = {
         "repo": "osbooks-writing-guide",
-        "uuid": "ee7ce46b-0972-4b2c-bc6e-8998c785cd57",
-        "slug": "writing-guide",
         "version": "4ff250a4779bc500660063acb85b7aab7df94396"
     }
 


### PR DESCRIPTION
We were including slugs for archive books because each ABL entry was for one book.

But the webhosting pipeline for git books only needs a repo and version; the slug is optional if you only want to build one of the books (like a CORGI job).

Including the slug was causing us to only build a subset of books in a repo and it caused us to build the same subset multiple times.