### PR TITLE
Update fetch_map_resources.py

### DIFF
--- a/bakery/src/scripts/fetch_map_resources.py
+++ b/bakery/src/scripts/fetch_map_resources.py
@@ -41,7 +41,7 @@ def main():
 
     for child in original_resources_dir.glob('*'):
         if child.is_dir():
-            shutil.move(child, resources_dir / child.name)
+            shutil.move(str(child), str(resources_dir / child.name))
 
     for cnxml_file in cnxml_files:
         doc = etree.parse(str(cnxml_file))


### PR DESCRIPTION
While trying to run [enki](https://github.com/openstax/enki) in a dev container this error popped up and [this fix from here](https://stackoverflow.com/questions/61327385/trying-to-use-on-path-object-python) seems to have solved the problem:

```
'PosixPath' object has no attribute 'rstrip'
```

I'm not sure why running in a devcontainer breaks. Maybe because it uses different paths to the input/output files?